### PR TITLE
도메인 설계하기

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,8 @@ erDiagram
         STRING green
         STRING blue
         STRING purple
+        DATETIME createdAt
+        DATETIME updatedAt
         DATETIME deletedAt
         STRING hashedRefreshToken
     }
@@ -68,17 +70,23 @@ erDiagram
         STRING description
         DATETIME date
         INTEGER score
+        DATETIME createdAt
+        DATETIME updatedAt
         DATETIME deletedAt
     }
 
     Favorite {
         LONG id
+        DATETIME createdAt
+        DATETIME updatedAt
         DATETIME deletedAt
     }
 
     Image {
         LONG id
         STRING uri
+        DATETIME createdAt
+        DATETIME updatedAt
         DATETIME deletedAt
     }
 ```

--- a/src/main/java/svsite/matzip/foody/domain/auth/entity/LoginType.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/entity/LoginType.java
@@ -1,0 +1,5 @@
+package svsite.matzip.foody.domain.auth.entity;
+
+public enum LoginType {
+  EMAIL, KAKAO, APPLE
+}

--- a/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
@@ -1,0 +1,80 @@
+package svsite.matzip.foody.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import svsite.matzip.foody.global.entity.BaseEntity;
+
+@Entity
+@Table(name = "users", indexes = {
+    @Index(name = "idx_user_email", columnList = "email")
+})
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)  // 기본 생성자 보호
+public class User extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  private LoginType loginType;
+
+  @Column(unique = true, nullable = false, length = 100)
+  private String email;
+
+  @Column(nullable = false, length = 200)
+  private String password;
+
+  @Column(nullable = false, length = 50)
+  private String nickname;
+
+  @Column(length = 255)
+  private String imageUri;
+
+  @Column(length = 255)
+  private String kakaoImageUri;
+
+  @Column(nullable = false, length = 50)
+  private String RED;
+
+  @Column(nullable = false, length = 50)
+  private String YELLOW;
+
+  @Column(nullable = false, length = 50)
+  private String GREEN;
+
+  @Column(nullable = false, length = 50)
+  private String BLUE;
+
+  @Column(nullable = false, length = 50)
+  private String PURPLE;
+
+  @Column(length = 255)
+  private String hashedRefreshToken;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if(!(o instanceof User user)) return false;
+    return id != null && id.equals(user.id);
+  }
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId());
+  }
+}

--- a/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
@@ -24,7 +24,7 @@ import svsite.matzip.foody.global.entity.BaseEntity;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)  // 기본 생성자 보호
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
   @Id

--- a/src/main/java/svsite/matzip/foody/domain/favorite/entity/Favorite.java
+++ b/src/main/java/svsite/matzip/foody/domain/favorite/entity/Favorite.java
@@ -1,0 +1,59 @@
+package svsite.matzip.foody.domain.favorite.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.post.entity.Post;
+import svsite.matzip.foody.global.entity.BaseEntity;
+
+@Entity
+@Table(name = "favorite",
+    uniqueConstraints = @UniqueConstraint(name = "uk_favorite_user_post", columnNames = {"user_id", "post_id"}),
+    indexes = {
+        @Index(name = "idx_favorite_user", columnList = "user_id"),
+        @Index(name = "idx_favorite_post", columnList = "post_id")
+    })
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Favorite extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Favorite favorite)) return false;
+    return id != null && id.equals(favorite.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId());
+  }
+}

--- a/src/main/java/svsite/matzip/foody/domain/image/api/Image.java
+++ b/src/main/java/svsite/matzip/foody/domain/image/api/Image.java
@@ -1,6 +1,5 @@
 package svsite.matzip.foody.domain.image.api;
 
-import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.FetchType.LAZY;
 
 import jakarta.persistence.Entity;
@@ -31,7 +30,7 @@ public class Image extends BaseEntity {
 
   private String uri;
 
-  @ManyToOne(fetch = LAZY, cascade = REMOVE)
+  @ManyToOne(fetch = LAZY)
   @JoinColumn(name="post_id")
   Post post;
 

--- a/src/main/java/svsite/matzip/foody/domain/image/api/Image.java
+++ b/src/main/java/svsite/matzip/foody/domain/image/api/Image.java
@@ -1,0 +1,48 @@
+package svsite.matzip.foody.domain.image.api;
+
+import static jakarta.persistence.CascadeType.REMOVE;
+import static jakarta.persistence.FetchType.LAZY;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import svsite.matzip.foody.domain.post.entity.Post;
+import svsite.matzip.foody.global.entity.BaseEntity;
+
+@Entity
+@Table(name = "image")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image extends BaseEntity {
+  @Id
+  @GeneratedValue
+  private Long id;
+
+  private String uri;
+
+  @ManyToOne(fetch = LAZY, cascade = REMOVE)
+  @JoinColumn(name="post_id")
+  Post post;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if(!(o instanceof Image image)) return false;
+    return id != null && id.equals(image.id);
+  }
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId());
+  }
+}

--- a/src/main/java/svsite/matzip/foody/domain/post/entity/MarkerColor.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/entity/MarkerColor.java
@@ -1,0 +1,18 @@
+package svsite.matzip.foody.domain.post.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum MarkerColor {
+    RED("RED"),
+    BLUE("BLUE"),
+    GREEN("GREEN"),
+    YELLOW("YELLOW"),
+    PURPLE("PURPLE");
+
+    private final String colorName;
+
+    MarkerColor(String colorName) {
+        this.colorName = colorName;
+    }
+}

--- a/src/main/java/svsite/matzip/foody/domain/post/entity/Post.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/entity/Post.java
@@ -1,0 +1,74 @@
+package svsite.matzip.foody.domain.post.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.global.entity.BaseEntity;
+
+@Entity
+@Table(name = "post")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(precision = 10, scale = 6)
+  private BigDecimal latitude;
+
+  @Column(precision = 10, scale = 6)
+  private BigDecimal longitude;
+
+  @Enumerated(EnumType.STRING)
+  private MarkerColor color;
+
+  @Column(length = 255)
+  private String address;
+  @Column(nullable = false, length = 100)
+  private String title;
+  @Lob
+  private String description;
+
+  private LocalDateTime date;
+
+  private Integer score;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if(!(o instanceof Post post)) return false;
+    return id != null && id.equals(post.id);
+  }
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId());
+  }
+}
+

--- a/src/main/java/svsite/matzip/foody/global/entity/BaseEntity.java
+++ b/src/main/java/svsite/matzip/foody/global/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package svsite.matzip.foody.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.cglib.core.Local;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(value={AuditingEntityListener.class})
+@Getter
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+}


### PR DESCRIPTION
이번 PR에서는 애플리케이션의 핵심 도메인 모델을 구성하기 위해 기본 엔티티들을 구현했습니다.
주요 변경 사항 및 설계 의도는 다음과 같습니다.

1. User 엔티티
   - 사용자 정보를 관리하기 위한 엔티티로, 로그인 타입, 이메일, 비밀번호, 닉네임, 이미지 URI, 카카오 이미지 URI 등 필드를 포함합니다.
   - 이메일 필드에 unique 제약 조건과 인덱스(idx_user_email)를 추가하여 데이터 무결성과 조회 성능을 고려했습니다.
   - 추가로 RED, YELLOW, GREEN, BLUE, PURPLE 등의 컬럼이 있는데, 이는 향후 사용자 관련 색상 설정(또는 기타 의미 있는 값)으로 활용할 예정입니다.
   - equals와 hashCode는 id를 기준으로 구현하여, 엔티티 비교 시 안정성을 확보했습니다.

2. Post 엔티티
   - 게시글 데이터를 관리하기 위한 엔티티로, 위도/경도, 마커 색상, 주소, 제목, 본문(대용량 텍스트 처리 위해 @Lob 사용), 작성 일자, 점수 등의 정보를 포함합니다.
   - 게시글 작성자와의 관계는 ManyToOne으로 User 엔티티와 연관되어 있으며, LAZY 로딩으로 설정해 불필요한 데이터 로딩을 최소화했습니다.
   - equals와 hashCode는 id 기반으로 구현되어 있습니다.

3. Favorite 엔티티
   - 사용자가 특정 게시글을 즐겨찾기하는 기능을 위한 엔티티입니다.
   - User와 Post 엔티티와 각각 ManyToOne 관계로 연결되며, (user_id, post_id) 조합에 대해 유니크 제약 조건(uk_favorite_user_post)을 설정하여 한 사용자가 동일한 게시글을 중복 즐겨찾기하지 못하도록 했습니다.
   - 외래키 컬럼(user_id, post_id)에 별도 인덱스를 추가하여 조회 성능을 개선했습니다.

4. Image 엔티티
   - 게시글에 첨부되는 이미지 정보를 관리하기 위한 엔티티입니다.
   - 이미지 URI와 함께, 해당 이미지가 속한 게시글(Post)과 ManyToOne 관계로 연결되어 있습니다.
   - equals와 hashCode는 id를 기준으로 구현되어 있습니다.

공통 사항:
- 모든 엔티티는 BaseEntity를 상속받아, 생성/수정 일자 등의 공통 필드를 관리합니다.
- Lombok(@Getter, @Builder, @AllArgsConstructor, @NoArgsConstructor)로 보일러플레이트 코드를 최소화했습니다.

이 구현은 초기 도메인 모델로서, 실제 서비스 요구사항에 따라 추가적인 수정이나 보완이 필요할 수 있습니다.
