### PR TITLE
엔티티 관계 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/readme.md
+++ b/readme.md
@@ -167,3 +167,20 @@ sequenceDiagram
 
 ## 7. 트러블 슈팅
 
+<details>
+<summary style="cursor: pointer">스프링 프로젝트 시작 후 바로 종료(shutdown)</summary>
+<div markdown="1">
+
+- 문제 상황
+```gradle
+com.zaxxer.hikari.HikariDataSource : HikariPool-1 - Shutdown initiated.
+```
+
+- 해결
+- 처음 의존성 설정 시 아래와 같은 의존성이 빠져 있었음
+```gradle
+implementation 'org.springframework.boot:spring-boot-starter-web'
+```
+
+</div>
+</details>

--- a/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
@@ -8,13 +8,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.List;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import svsite.matzip.foody.domain.favorite.entity.Favorite;
 import svsite.matzip.foody.global.entity.BaseEntity;
 
 @Entity
@@ -66,6 +69,9 @@ public class User extends BaseEntity {
 
   @Column(length = 255)
   private String hashedRefreshToken;
+
+  @OneToMany(mappedBy = "user", orphanRemoval = true)
+  private List<Favorite> favorites;
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/svsite/matzip/foody/domain/post/entity/Post.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/entity/Post.java
@@ -2,6 +2,7 @@ package svsite.matzip.foody.domain.post.entity;
 
 import static jakarta.persistence.FetchType.LAZY;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,9 +13,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,6 +26,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.favorite.entity.Favorite;
+import svsite.matzip.foody.domain.image.api.Image;
 import svsite.matzip.foody.global.entity.BaseEntity;
 
 @Entity
@@ -59,6 +65,13 @@ public class Post extends BaseEntity {
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "user_id")
   private User user;
+
+  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<Image> images = new ArrayList<>();
+
+  @OneToMany(mappedBy = "post", orphanRemoval = true)
+  private List<Favorite> favorites;
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/svsite/matzip/foody/global/config/AuditConfig.java
+++ b/src/main/java/svsite/matzip/foody/global/config/AuditConfig.java
@@ -1,0 +1,10 @@
+package svsite.matzip.foody.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditConfig {
+}
+


### PR DESCRIPTION
### **PR 제목:**  
`엔티티 관계 설정 및 Auditing 기능 추가`

---

### **PR 설명**

#### **1. PR 개요**  
User, Post 엔티티에 연관 관계를 설정하고, `BaseEntity`를 적용하기 위해 Auditing 기능을 활성화했습니다.

---

### **2. 주요 변경 사항 및 설명**

##### **1) User-Favorite 연관 관계 설정**
- User 엔티티에 Favorite 엔티티와의 `@OneToMany` 관계를 추가했습니다.
- 연관 관계 설정:
  ```java
  @OneToMany(mappedBy = "user", orphanRemoval = true)
  private List<Favorite> favorites;
  ```
- **설계 의도:**  
  - 한 사용자가 여러 게시글을 즐겨찾기할 수 있으며, 사용자가 삭제될 경우 해당 사용자의 즐겨찾기(Favorite) 데이터도 함께 제거되도록 설정했습니다.

---

##### **2) Post-Image, Post-Favorite 연관 관계 설정**
- Post 엔티티에 Favorite 및 Image 엔티티와의 연관 관계를 설정했습니다.
- 연관 관계 설정:
  ```java
  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
  @Builder.Default
  private List<Image> images = new ArrayList<>();

  @OneToMany(mappedBy = "post", orphanRemoval = true)
  private List<Favorite> favorites;
  ```
- **설계 의도:**  
  - 게시글이 삭제될 경우 관련 이미지와 즐겨찾기 데이터도 함께 삭제되도록 설정했습니다.
  - `CascadeType.ALL`로 설정하여 게시글 생성 및 삭제 시 이미지 데이터가 자동으로 처리되도록 했습니다.

---

##### **3) Auditing 기능 설정**
- `BaseEntity`에 적용하기 위해 Auditing 기능을 활성화했습니다.
- 설정 코드:
  ```java
  @Configuration
  @EnableJpaAuditing
  public class AuditConfig {
  }
  ```
- **설계 의도:**  
  - `@EnableJpaAuditing`을 통해 엔티티의 생성 및 수정 일자가 자동으로 관리되도록 설정했습니다.

---

### **3. 설계 의도 및 고려 사항**
- 모든 엔티티는 `BaseEntity`를 상속받아 공통 필드(생성일, 수정일)를 관리합니다.
- `@OneToMany` 관계에 `orphanRemoval = true`를 적용하여 연관된 데이터가 올바르게 삭제되도록 했습니다.
- Post와 Image 관계에 `CascadeType.ALL`을 설정하여 이미지가 게시글과 함께 자동으로 관리됩니다.
- `FetchType.LAZY`는 기본 설정으로 유지해 필요할 때만 연관 데이터를 로드하도록 했습니다.

---
### **4. 이슈**
##### **1) Spring web 의존성 누락**
- 부트 프로젝트 시작 후 바로 종료되는 이슈가 발생했습니다.
- spring web 의존성이 누락되었다는 것을 파악하고 조치하였습니다.

---

### **5. 기타 사항**
- 

---

**This closes #7**