### PR TITLE
예외 처리 전략 구현 및 공통 응답 구조 통일

### DIFF
--- a/src/main/java/svsite/matzip/foody/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/svsite/matzip/foody/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,112 @@
+package svsite.matzip.foody.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+import svsite.matzip.foody.global.exception.response.ApiResponseError;
+import svsite.matzip.foody.global.exception.support.CustomException;
+
+@Slf4j
+@RestControllerAdvice
+public final class GlobalExceptionHandler {
+
+  // CustomException 핸들링
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ApiResponseError> handleCustomException(CustomException exception,
+      HttpServletRequest request) {
+    return handleException(
+        "CUSTOM_ERROR", exception.getErrorCode().defaultHttpStatus(), exception.getMessage(),
+        request, true
+    );
+  }
+
+  // 유효성 검사 실패 예외
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiResponseError> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException exception, HttpServletRequest request) {
+
+    return handleException(
+        "VALIDATION_ERROR", HttpStatus.BAD_REQUEST, "유효성 검사가 실패했습니다.", request, false
+    );
+  }
+
+  // 파일 업로드 크기 초과 예외
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public ResponseEntity<ApiResponseError> handleMaxUploadSizeExceededException(
+      MaxUploadSizeExceededException exception, HttpServletRequest request) {
+
+    return handleException(
+        "UPLOAD_SIZE_EXCEEDED", HttpStatus.PAYLOAD_TOO_LARGE, "업로드 가능한 최대 파일 크기를 초과했습니다.", request,
+        false
+    );
+  }
+
+  // 바인딩 예외
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<ApiResponseError> handleBindException(BindException exception,
+      HttpServletRequest request) {
+    String message =
+        exception.getFieldError() != null ? exception.getFieldError().getDefaultMessage()
+            : "요청 바인딩에 실패했습니다.";
+    return handleException("BIND_ERROR", HttpStatus.BAD_REQUEST, message, request, false);
+  }
+
+  // 리소스 찾기 실패 예외
+  @ExceptionHandler(NoResourceFoundException.class)
+  public ResponseEntity<ApiResponseError> handleNoResourceFoundException(
+      NoResourceFoundException exception, HttpServletRequest request) {
+    return handleException(
+        "RESOURCE_NOT_FOUND", HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다.", request, false
+    );
+  }
+
+  // 필수 요청 파라미터 누락 예외
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<ApiResponseError> handleMissingServletRequestParameterException(
+      MissingServletRequestParameterException exception, HttpServletRequest request) {
+
+    String message = String.format("필수 요청 파라미터 '%s'가 누락되었습니다.", exception.getParameterName());
+    return handleException("MISSING_PARAMETER", HttpStatus.BAD_REQUEST, message, request, false);
+  }
+
+  // 요청 파라미터 타입 불일치 예외
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ApiResponseError> handleMethodArgumentTypeMismatchException(
+      MethodArgumentTypeMismatchException exception, HttpServletRequest request) {
+
+    String message = String.format("파라미터 '%s'의 값 '%s'가 올바르지 않습니다.", exception.getName(),
+        exception.getValue());
+    return handleException("TYPE_MISMATCH", HttpStatus.BAD_REQUEST, message, request, false);
+  }
+
+  // 공통 예외 처리 메서드
+  private ResponseEntity<ApiResponseError> handleException(
+      String code, HttpStatus status, String message, HttpServletRequest request, boolean isError) {
+
+    if (isError) {
+      log.error("Exception 발생 - Path: {}, Message: {}", request.getRequestURI(), message);
+    } else {
+      log.warn("Exception 발생 - Path: {}, Message: {}", request.getRequestURI(), message);
+    }
+
+    ApiResponseError response = ApiResponseError.builder()
+        .code(code)
+        .status(status.value())
+        .message(message)
+        .timestamp(Instant.now())
+        .path(request.getRequestURI())
+        .build();
+
+    return ResponseEntity.status(status).body(response);
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/exception/errorCode/ErrorCodes.java
+++ b/src/main/java/svsite/matzip/foody/global/exception/errorCode/ErrorCodes.java
@@ -1,0 +1,50 @@
+package svsite.matzip.foody.global.exception.errorCode;
+
+import org.springframework.http.HttpStatus;
+import svsite.matzip.foody.global.exception.support.CustomException;
+import svsite.matzip.foody.global.exception.support.ErrorCode;
+
+public enum ErrorCodes implements ErrorCode {
+  USER_NOT_FOUND("해당 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  USER_EMAIL_DUPLICATE("회원 이메일이 중복됩니다.", HttpStatus.CONFLICT),
+  USER_WRONG_ID_OR_PASSWORD("아이디 혹은 비밀번호가 잘못되었습니다.", HttpStatus.BAD_REQUEST),
+  USER_WRONG_PASSWORD("비밀번호가 잘못되었습니다.", HttpStatus.BAD_REQUEST),
+
+
+  POST_NOT_FOUND("해당 게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  POST_CONTENT_NEED("게시글의 내용을 입력해주세요.", HttpStatus.BAD_REQUEST),
+  POST_NOT_MATCHING_USER("게시글 작성자만 게시글을 변경 가능합니다.", HttpStatus.BAD_REQUEST),
+
+  FAVORITE_DUPLICATE("즐겨 찾기를 중복으로 할 수 없습니다.", HttpStatus.CONFLICT),
+
+  FILE_SIZE_OUT("파일 크기는 최대 20MB 입니다", HttpStatus.CONFLICT),
+  ;
+
+  private final String message;
+  private final HttpStatus httpStatus;
+
+  ErrorCodes(String message, HttpStatus httpStatus) {
+    this.message = message;
+    this.httpStatus = httpStatus;
+  }
+
+  @Override
+  public String defaultMessage() {
+    return this.message;
+  }
+
+  @Override
+  public HttpStatus defaultHttpStatus() {
+    return this.httpStatus;
+  }
+
+  @Override
+  public CustomException defaultException() {
+    return new CustomException(this);
+  }
+
+  @Override
+  public CustomException defaultException(Throwable cause) {
+    return new CustomException(this, cause);
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/exception/response/ApiResponseError.java
+++ b/src/main/java/svsite/matzip/foody/global/exception/response/ApiResponseError.java
@@ -1,0 +1,77 @@
+package svsite.matzip.foody.global.exception.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.time.Instant;
+import java.util.List;
+import lombok.Builder;
+import svsite.matzip.foody.global.exception.support.CustomException;
+import svsite.matzip.foody.global.exception.support.ErrorCode;
+import svsite.matzip.foody.global.util.text.TextCaseUtil;
+
+/**
+ *
+ * @param code 에러 코드 명
+ * @param status 상태 코드 값
+ * @param name 오류 이름
+ * @param message 오류 메시지
+ * @param error HTTP 상태 코드 이름
+ * @param cause
+ * @param timestamp 발생 시각
+ */
+@Builder
+public record ApiResponseError(
+    String code,
+    Integer status,
+    String name,
+    String message,
+    String error,
+    @JsonInclude(Include.NON_EMPTY) List<ApiSimpleError> cause,
+    Instant timestamp,
+    @JsonInclude(Include.NON_NULL) String path
+) {
+  public static ApiResponseError of(CustomException exception, String path) {
+    ErrorCode errorCode = exception.getErrorCode();
+    String errorName = exception.getClass().getName();
+    errorName = errorName.substring(errorName.lastIndexOf('.') + 1);
+    String error = TextCaseUtil.capitalizeAndSaveUpperSnakeCase(
+        errorCode.defaultHttpStatus().name()
+    );
+
+    return ApiResponseError.builder()
+        .code(errorCode.name())
+        .status(errorCode.defaultHttpStatus().value())
+        .name(errorName)
+        .message(exception.getMessage())
+        .error(error)
+        .cause(ApiSimpleError.listOfCauseSimpleError(exception))
+        .path(path)
+        .build();
+  }
+
+  public static ApiResponseError of(CustomException exception) {
+    return of(exception, null);
+  }
+
+  public ApiResponseError {
+    if (code == null) {
+      code = "API_ERROR";
+    }
+
+    if (status == null) {
+      status = 500;
+    }
+
+    if (name == null) {
+      name = "ApiError";
+    }
+
+    if (message == null || message.isBlank()) {
+      message = "API 오류";
+    }
+
+    if (timestamp == null) {
+      timestamp = Instant.now();
+    }
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/exception/response/ApiSimpleError.java
+++ b/src/main/java/svsite/matzip/foody/global/exception/response/ApiSimpleError.java
@@ -1,0 +1,38 @@
+package svsite.matzip.foody.global.exception.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder
+public record ApiSimpleError(@NonNull String field, @NonNull String message) {
+  public static List<ApiSimpleError> listOfCauseSimpleError(Throwable cause) {
+    return List.of(normalizeCause(cause));
+  }
+
+  public static ApiSimpleError[] normalizeCause(Throwable cause) {
+    int depth = 0;
+    ApiSimpleError[] subErrors;
+    Throwable currentCause = cause.getCause();
+
+    while (currentCause != null) {
+      currentCause = currentCause.getCause();
+      depth++;
+    }
+
+    subErrors = new ApiSimpleError[depth];
+    currentCause = cause;
+    for (int i = 0; i < depth; i++) {
+      String errorFullName = currentCause.getClass().getSimpleName();
+      String field = errorFullName.substring(errorFullName.lastIndexOf('.') + 1);
+      subErrors[i] = ApiSimpleError.builder()
+          .field(field)
+          .message(currentCause.getLocalizedMessage())
+          .build();
+
+      currentCause = currentCause.getCause();
+    }
+
+    return subErrors;
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/exception/support/CustomException.java
+++ b/src/main/java/svsite/matzip/foody/global/exception/support/CustomException.java
@@ -1,0 +1,67 @@
+package svsite.matzip.foody.global.exception.support;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+  private static ErrorCode getDefaultErrorCode() {
+    return DefaultErrorCodeHolder.DEFAULT_ERROR_CODE;
+  }
+
+  protected final ErrorCode errorCode;
+
+  public CustomException() {
+    super(getDefaultErrorCode().defaultMessage());
+    this.errorCode = getDefaultErrorCode();
+  }
+
+  public CustomException(String message) {
+    super(message);
+    this.errorCode = getDefaultErrorCode();
+  }
+
+  public CustomException(String message, Throwable cause) {
+    super(message, cause);
+    this.errorCode = getDefaultErrorCode();
+  }
+
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.defaultMessage());
+    this.errorCode = errorCode;
+  }
+
+  public CustomException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode.defaultMessage(), cause);
+    this.errorCode = errorCode;
+  }
+
+  private static class DefaultErrorCodeHolder { // 사용할 때 로드 + 스레드 세이프(클래스 로드 타임은 동시성 보장됨.)
+    private static final ErrorCode DEFAULT_ERROR_CODE = new ErrorCode() {
+      @Override
+      public String name() {
+        return "SERVER_ERROR";
+      }
+
+      @Override
+      public HttpStatus defaultHttpStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+      }
+
+      @Override
+      public String defaultMessage() {
+        return "서버 오류";
+      }
+
+      @Override
+      public CustomException defaultException() {
+        return new CustomException(this);
+      }
+
+      @Override
+      public CustomException defaultException(Throwable cause) {
+        return new CustomException(this, cause);
+      }
+    };
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/exception/support/ErrorCode.java
+++ b/src/main/java/svsite/matzip/foody/global/exception/support/ErrorCode.java
@@ -1,0 +1,11 @@
+package svsite.matzip.foody.global.exception.support;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+  String name();
+  String defaultMessage();
+  HttpStatus defaultHttpStatus();
+  RuntimeException defaultException();
+  RuntimeException defaultException(Throwable cause);
+}

--- a/src/main/java/svsite/matzip/foody/global/util/text/TextCaseUtil.java
+++ b/src/main/java/svsite/matzip/foody/global/util/text/TextCaseUtil.java
@@ -1,0 +1,32 @@
+package svsite.matzip.foody.global.util.text;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class TextCaseUtil {
+
+  private static final ConcurrentHashMap<String, String> cachedCapitalizationMap = new ConcurrentHashMap<>();
+
+  public static String capitalizeAndSaveUpperSnakeCase(String upperSnakeCase) {
+    return cachedCapitalizationMap.computeIfAbsent(upperSnakeCase, TextCaseUtil::capitalizeUpperSnakeCase);
+  }
+
+  public static String capitalizeUpperSnakeCase(String upperSnakeCase) {
+    char[] chars = upperSnakeCase.toCharArray();
+    boolean willBeLower = false;
+
+    for (int i = 0; i < chars.length; i++) {
+      char ch = chars[i];
+      if (willBeLower && 'A' <= ch && ch <= 'Z') {
+        ch |= ' '; // ch = ch | ' ';
+      } else if (ch == '_') {
+        ch = ' ';
+        willBeLower = false;
+      } else {
+        willBeLower = true;
+      }
+      chars[i] = ch;
+    }
+
+    return new String(chars);
+  }
+}


### PR DESCRIPTION
### **1. PR 개요**  
예외 처리 로직을 `GlobalExceptionHandler`에 구현하고, 공통 예외 응답 구조를 설정했습니다. 이를 통해 모든 예외 상황에서 일관된 API 응답을 반환하도록 개선했습니다.

---

### **2. 주요 변경 사항 및 설명**

##### **1) 예외 처리 핸들러 추가 (GlobalExceptionHandler)**  
- `@RestControllerAdvice`를 사용해 전역 예외 처리 핸들러를 구현했습니다.
- 주요 예외 핸들러 목록:
  ```java
  @ExceptionHandler(CustomException.class)
  public ResponseEntity<ApiResponseError> handleCustomException(CustomException exception, HttpServletRequest request);

  @ExceptionHandler(MethodArgumentNotValidException.class)
  public ResponseEntity<ApiResponseError> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception, HttpServletRequest request);

  @ExceptionHandler(MaxUploadSizeExceededException.class)
  public ResponseEntity<ApiResponseError> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException exception, HttpServletRequest request);

  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
  public ResponseEntity<ApiResponseError> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException exception, HttpServletRequest request);
  ```
- **설계 의도:**  
  - 주요 예외 발생 시 상태 코드와 메시지를 통일된 형식으로 반환하여 클라이언트가 예외를 쉽게 파악할 수 있도록 했습니다.
  - 예외의 심각성에 따라 로깅 레벨을 구분하여 기록(`log.error`, `log.warn`).

---

##### **2) 공통 응답 구조 정의 (ApiResponseError)**  
- 예외 응답을 위한 공통 구조인 `ApiResponseError`를 추가했습니다.
- 응답 객체 구조 예시:
  ```json
  {
      "code": "RESOURCE_NOT_FOUND",
      "status": 404,
      "message": "요청한 리소스를 찾을 수 없습니다.",
      "timestamp": "2025-02-02T15:00:00Z",
      "path": "/api/posts/123"
  }
  ```
- **설계 의도:**  
  - 모든 예외 응답에 코드(`code`), 상태(`status`), 메시지(`message`), 발생 시각(`timestamp`), 요청 경로(`path`)를 포함시켜 일관된 구조를 유지.
  - `handleException()` 메서드로 공통 응답 생성 로직을 관리하여 코드 중복을 줄였습니다.
  
---

##### **3) 에러 코드 관리 및 CustomException 구현**
- 예외 상황에 따라 사용할 에러 코드를 `ErrorCodes` Enum으로 관리합니다.
- `CustomException` 클래스는 비즈니스 로직에서 사용자 정의 예외를 발생시킬 때 사용됩니다.
  ```java
  public enum ErrorCodes implements ErrorCode {
      USER_NOT_FOUND("해당 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
      POST_NOT_FOUND("해당 게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
  }

  public class CustomException extends RuntimeException {
      private final ErrorCode errorCode;

      public CustomException(ErrorCode errorCode) {
          super(errorCode.defaultMessage());
          this.errorCode = errorCode;
      }
  }
  ```
- **설계 의도:**  
  - 에러 코드 및 메시지를 Enum으로 관리해 코드의 확장성과 가독성을 높였습니다.
  - `CustomException`을 통해 특정 비즈니스 로직에서의 예외 발생을 명확하게 표현할 수 있습니다.

---

### **3. 설계 의도 및 고려 사항**
- 공통 응답 구조(`ApiResponseError`)를 통해 클라이언트가 예외 상황을 쉽게 이해할 수 있도록 했습니다.
- 예외 발생 시 요청 경로와 메시지를 포함하여 로깅 정보를 강화했습니다.

---

### **4. 이슈**
##### **1) API 예외 발생 시 응답 형식 변경 요구**
- 기존에는 다양한 예외에서 서로 다른 형식으로 응답이 반환되었으나, 이번 PR에서 통일된 형식으로 개선했습니다.

---

### **5. 기타 사항**
- 예외 발생 시 각 요청에 대한 추가 정보를 로그에 기록하는 부분은 차후 요구사항에 따라 확장 가능합니다.

---

**This closes #9**