### PR TITLE
회원가입/로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,4 @@ gradle-app.setting
 /.idea/**
 # resources 디렉터리 내 특정 yml 파일 무시
 /src/main/resources/application-*.yml
+*.gz

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 
     // 로깅
     implementation 'org.springframework.boot:spring-boot-starter-logging'
+
+    // 암호화
+    implementation 'org.springframework.security:spring-security-crypto:6.0.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 
     // 암호화
     implementation 'org.springframework.security:spring-security-crypto:6.0.0'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
@@ -1,0 +1,26 @@
+package svsite.matzip.foody.domain.auth.api;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import svsite.matzip.foody.domain.auth.api.dto.request.AuthRequestDto;
+import svsite.matzip.foody.domain.auth.service.AuthService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+  private final AuthService authService;
+
+  @PostMapping("/signup")
+  public ResponseEntity<Long> signup(@RequestBody @Valid AuthRequestDto authRequestDto) {
+    return ResponseEntity.ok(authService.signup(authRequestDto));
+  }
+}

--- a/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
@@ -1,5 +1,7 @@
 package svsite.matzip.foody.domain.auth.api;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import svsite.matzip.foody.domain.auth.api.dto.request.AuthRequestDto;
+import svsite.matzip.foody.domain.auth.api.dto.response.TokenResponseDto;
 import svsite.matzip.foody.domain.auth.service.AuthService;
 
 @Tag(name = "Auth", description = "회원 인증 관련 API")
@@ -31,5 +34,16 @@ public class AuthController {
   @PostMapping("/signup")
   public ResponseEntity<Long> signup(@RequestBody @Valid AuthRequestDto authRequestDto) {
     return ResponseEntity.ok(authService.signup(authRequestDto));
+  }
+
+  @Operation(summary = "로그인", description = "사용자가 로그인 합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
+  @PostMapping("/signin")
+  public ResponseEntity<TokenResponseDto> signin(@RequestBody @Valid AuthRequestDto authRequestDto) {
+    return ResponseEntity.ok().body(authService.signin(authRequestDto));
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
@@ -8,14 +8,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import svsite.matzip.foody.domain.auth.api.dto.request.AuthRequestDto;
 import svsite.matzip.foody.domain.auth.api.dto.response.TokenResponseDto;
+import svsite.matzip.foody.domain.auth.entity.User;
 import svsite.matzip.foody.domain.auth.service.AuthService;
+import svsite.matzip.foody.global.auth.AuthenticatedUser;
+import svsite.matzip.foody.global.util.jwt.JwtTokenType;
 
 @Tag(name = "Auth", description = "회원 인증 관련 API")
 @RestController
@@ -45,5 +50,12 @@ public class AuthController {
   @PostMapping("/signin")
   public ResponseEntity<TokenResponseDto> signin(@RequestBody @Valid AuthRequestDto authRequestDto) {
     return ResponseEntity.ok().body(authService.signin(authRequestDto));
+  }
+
+  @GetMapping("/refresh")
+  public ResponseEntity<TokenResponseDto> refresh(
+      @AuthenticatedUser(JwtTokenType.REFRESH) User user) {
+    TokenResponseDto tokens = authService.refreshToken(user);
+    return ResponseEntity.status(HttpStatus.CREATED).body(tokens);
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
@@ -1,7 +1,9 @@
 package svsite.matzip.foody.domain.auth.api;
 
-import static org.springframework.http.HttpStatus.CREATED;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import svsite.matzip.foody.domain.auth.api.dto.request.AuthRequestDto;
 import svsite.matzip.foody.domain.auth.service.AuthService;
 
+@Tag(name = "Auth", description = "회원 인증 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
@@ -19,6 +22,12 @@ public class AuthController {
 
   private final AuthService authService;
 
+  @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+      @ApiResponse(responseCode = "409", description = "중복된 이메일")
+  })
   @PostMapping("/signup")
   public ResponseEntity<Long> signup(@RequestBody @Valid AuthRequestDto authRequestDto) {
     return ResponseEntity.ok(authService.signup(authRequestDto));

--- a/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
@@ -1,10 +1,9 @@
 package svsite.matzip.foody.domain.auth.api;
 
-import static org.springframework.http.HttpStatus.CREATED;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -52,16 +51,22 @@ public class AuthController {
     return ResponseEntity.ok().body(authService.signin(authRequestDto));
   }
 
-  @Operation(summary = "엑세스, 리프레쉬 토큰 재발급", description = "엑세스 토큰 만료시 리프레쉬 토큰으로 재발급합니다.")
-  @ApiResponses({
-      @ApiResponse(responseCode = "201", description = "엑세스, 리프레쉬 토큰 재발급 성공"),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자"),
-      @ApiResponse(responseCode = "400", description = "잘못된 요청")
-  })
+  @Operation(summary = "엑세스, 리프레쉬 토큰 재발급",
+      description = "엑세스 토큰 만료 시 리프레쉬 토큰으로 재발급합니다.",
+      security = @SecurityRequirement(name = "bearerAuth"))
   @GetMapping("/refresh")
   public ResponseEntity<TokenResponseDto> refresh(
       @AuthenticatedUser(JwtTokenType.REFRESH) User user) {
     TokenResponseDto tokens = authService.refreshToken(user);
     return ResponseEntity.status(HttpStatus.CREATED).body(tokens);
+  }
+
+  @Operation(
+      summary = "로그아웃",
+      description = "사용자를 로그아웃하고 리프레쉬 토큰을 삭제합니다.",
+      security = @SecurityRequirement(name = "bearerAuth"))
+  @GetMapping("/logout")
+  public ResponseEntity<Long> logout(@AuthenticatedUser User user) {
+    return ResponseEntity.status(HttpStatus.OK).body(authService.deleteRefreshToken(user));
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/api/AuthController.java
@@ -52,6 +52,12 @@ public class AuthController {
     return ResponseEntity.ok().body(authService.signin(authRequestDto));
   }
 
+  @Operation(summary = "엑세스, 리프레쉬 토큰 재발급", description = "엑세스 토큰 만료시 리프레쉬 토큰으로 재발급합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "201", description = "엑세스, 리프레쉬 토큰 재발급 성공"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
   @GetMapping("/refresh")
   public ResponseEntity<TokenResponseDto> refresh(
       @AuthenticatedUser(JwtTokenType.REFRESH) User user) {

--- a/src/main/java/svsite/matzip/foody/domain/auth/api/dto/request/AuthRequestDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/api/dto/request/AuthRequestDto.java
@@ -1,0 +1,17 @@
+package svsite.matzip.foody.domain.auth.api.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record AuthRequestDto(
+    @NotEmpty
+    @Pattern(regexp = "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$", message = "이메일 형식이 아닙니다.")
+    @Size(min = 6, max = 50)
+    String email,
+
+    @NotEmpty
+    @Size(min = 8, max = 20)
+    @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "비밀번호가 영어와 숫자 조합이 아닙니다.")
+    String password
+) {}

--- a/src/main/java/svsite/matzip/foody/domain/auth/api/dto/request/AuthRequestDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/api/dto/request/AuthRequestDto.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "회원가입 요청 DTO")
+@Schema(description = "회원가입, 로그인 요청 DTO")
 public record AuthRequestDto(
     @Schema(
         description = "사용자 이메일",

--- a/src/main/java/svsite/matzip/foody/domain/auth/api/dto/request/AuthRequestDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/api/dto/request/AuthRequestDto.java
@@ -4,12 +4,28 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원가입 요청 DTO")
 public record AuthRequestDto(
+    @Schema(
+        description = "사용자 이메일",
+        example = "test@example.com",
+        minLength = 6,
+        maxLength = 50,
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotEmpty
     @Pattern(regexp = "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$", message = "이메일 형식이 아닙니다.")
-    @Size(min = 6, max = 50)
     String email,
 
+    @Schema(
+        description = "사용자 비밀번호",
+        example = "password123",
+        minLength = 8,
+        maxLength = 20,
+        requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotEmpty
     @Size(min = 8, max = 20)
     @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "비밀번호가 영어와 숫자 조합이 아닙니다.")

--- a/src/main/java/svsite/matzip/foody/domain/auth/api/dto/response/TokenResponseDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/api/dto/response/TokenResponseDto.java
@@ -1,0 +1,11 @@
+package svsite.matzip.foody.domain.auth.api.dto.response;
+
+import lombok.Builder;
+
+public record TokenResponseDto(
+    String accessToken,
+    String refreshToken
+) {
+  @Builder
+  public TokenResponseDto {}
+}

--- a/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
@@ -94,4 +94,8 @@ public class User extends BaseEntity {
   public int hashCode() {
     return Objects.hash(getId());
   }
+
+  public void updateHashedRefreshToken(String hashedRefreshToken) {
+    this.hashedRefreshToken = hashedRefreshToken;
+  }
 }

--- a/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
@@ -1,5 +1,7 @@
 package svsite.matzip.foody.domain.auth.entity;
 
+import static svsite.matzip.foody.domain.auth.entity.LoginType.EMAIL;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -17,6 +19,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import svsite.matzip.foody.domain.auth.api.dto.request.AuthRequestDto;
 import svsite.matzip.foody.domain.favorite.entity.Favorite;
 import svsite.matzip.foody.global.entity.BaseEntity;
 
@@ -72,6 +75,14 @@ public class User extends BaseEntity {
 
   @OneToMany(mappedBy = "user", orphanRemoval = true)
   private List<Favorite> favorites;
+
+  public static User signup(AuthRequestDto authDto, String hashedPassword) {
+    return User.builder()
+        .email(authDto.email())
+        .password(hashedPassword)
+        .loginType(EMAIL)
+        .build();
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/entity/User.java
@@ -46,7 +46,7 @@ public class User extends BaseEntity {
   @Column(nullable = false, length = 200)
   private String password;
 
-  @Column(nullable = false, length = 50)
+  @Column(length = 50)
   private String nickname;
 
   @Column(length = 255)
@@ -55,19 +55,19 @@ public class User extends BaseEntity {
   @Column(length = 255)
   private String kakaoImageUri;
 
-  @Column(nullable = false, length = 50)
+  @Column(length = 50)
   private String RED;
 
-  @Column(nullable = false, length = 50)
+  @Column(length = 50)
   private String YELLOW;
 
-  @Column(nullable = false, length = 50)
+  @Column(length = 50)
   private String GREEN;
 
-  @Column(nullable = false, length = 50)
+  @Column(length = 50)
   private String BLUE;
 
-  @Column(nullable = false, length = 50)
+  @Column(length = 50)
   private String PURPLE;
 
   @Column(length = 255)

--- a/src/main/java/svsite/matzip/foody/domain/auth/repository/UserRepository.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package svsite.matzip.foody.domain.auth.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import svsite.matzip.foody.domain.auth.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+  Optional<User> findByEmail(String email);
+}

--- a/src/main/java/svsite/matzip/foody/domain/auth/service/AuthService.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/service/AuthService.java
@@ -37,6 +37,7 @@ public class AuthService {
     return user.getId();
   }
 
+  @Transactional
   public TokenResponseDto signin(AuthRequestDto authRequestDto) {
     User user = userRepository.findByEmail(authRequestDto.email())
         .orElseThrow(() -> new CustomException(ErrorCodes.USER_NOT_FOUND));
@@ -49,6 +50,7 @@ public class AuthService {
     return tokenDto;
   }
 
+  @Transactional
   public TokenResponseDto getTokens(String email) {
     Map<String, Object> payload = new HashMap<>();
     payload.put(EMAIL, email);
@@ -62,9 +64,16 @@ public class AuthService {
     user.updateHashedRefreshToken(hashedRefreshToken);
   }
 
+  @Transactional
   public TokenResponseDto refreshToken(User user) {
     TokenResponseDto tokenDto = getTokens(user.getEmail());
     updateHashedRefreshToken(user, tokenDto.refreshToken());
     return tokenDto;
+  }
+
+  @Transactional
+  public long deleteRefreshToken(User user) {
+    user.updateHashedRefreshToken(null);
+    return user.getId();
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/auth/service/AuthService.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/service/AuthService.java
@@ -61,4 +61,10 @@ public class AuthService {
     String hashedRefreshToken = passwordEncoder.encode(refreshToken);
     user.updateHashedRefreshToken(hashedRefreshToken);
   }
+
+  public TokenResponseDto refreshToken(User user) {
+    TokenResponseDto tokenDto = getTokens(user.getEmail());
+    updateHashedRefreshToken(user, tokenDto.refreshToken());
+    return tokenDto;
+  }
 }

--- a/src/main/java/svsite/matzip/foody/domain/auth/service/AuthService.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/service/AuthService.java
@@ -1,0 +1,31 @@
+package svsite.matzip.foody.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import svsite.matzip.foody.domain.auth.api.dto.request.AuthRequestDto;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.auth.repository.UserRepository;
+import svsite.matzip.foody.global.exception.errorCode.ErrorCodes;
+import svsite.matzip.foody.global.exception.support.CustomException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  @Transactional
+  public Long signup(AuthRequestDto authRequestDto) {
+    if (userRepository.findByEmail(authRequestDto.email()).isPresent()) {
+      throw new CustomException(ErrorCodes.USER_EMAIL_DUPLICATE);
+    }
+    String hashedPassword = passwordEncoder.encode(authRequestDto.password());
+    User user = User.signup(authRequestDto, hashedPassword);
+    userRepository.save(user);
+    return user.getId();
+  }
+}

--- a/src/main/java/svsite/matzip/foody/domain/auth/service/AuthService.java
+++ b/src/main/java/svsite/matzip/foody/domain/auth/service/AuthService.java
@@ -1,14 +1,21 @@
 package svsite.matzip.foody.domain.auth.service;
 
+import static svsite.matzip.foody.global.constant.Constant.EMAIL;
+import static svsite.matzip.foody.global.exception.errorCode.ErrorCodes.USER_WRONG_PASSWORD;
+
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import svsite.matzip.foody.domain.auth.api.dto.request.AuthRequestDto;
+import svsite.matzip.foody.domain.auth.api.dto.response.TokenResponseDto;
 import svsite.matzip.foody.domain.auth.entity.User;
 import svsite.matzip.foody.domain.auth.repository.UserRepository;
 import svsite.matzip.foody.global.exception.errorCode.ErrorCodes;
 import svsite.matzip.foody.global.exception.support.CustomException;
+import svsite.matzip.foody.global.util.jwt.JwtUtil;
 
 @Service
 @Transactional
@@ -17,6 +24,7 @@ public class AuthService {
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
+  private final JwtUtil jwtUtil;
 
   @Transactional
   public Long signup(AuthRequestDto authRequestDto) {
@@ -27,5 +35,30 @@ public class AuthService {
     User user = User.signup(authRequestDto, hashedPassword);
     userRepository.save(user);
     return user.getId();
+  }
+
+  public TokenResponseDto signin(AuthRequestDto authRequestDto) {
+    User user = userRepository.findByEmail(authRequestDto.email())
+        .orElseThrow(() -> new CustomException(ErrorCodes.USER_NOT_FOUND));
+
+    if (!passwordEncoder.matches(authRequestDto.password(), user.getPassword())) {
+      throw new CustomException(USER_WRONG_PASSWORD);
+    }
+    TokenResponseDto tokenDto = getTokens(authRequestDto.email());
+    updateHashedRefreshToken(user, tokenDto.refreshToken());
+    return tokenDto;
+  }
+
+  public TokenResponseDto getTokens(String email) {
+    Map<String, Object> payload = new HashMap<>();
+    payload.put(EMAIL, email);
+    String accessToken = jwtUtil.generateAccessToken(payload);
+    String refreshToken = jwtUtil.generateRefreshToken(payload);
+    return new TokenResponseDto(accessToken, refreshToken);
+  }
+
+  private void updateHashedRefreshToken(User user, String refreshToken) {
+    String hashedRefreshToken = passwordEncoder.encode(refreshToken);
+    user.updateHashedRefreshToken(hashedRefreshToken);
   }
 }

--- a/src/main/java/svsite/matzip/foody/global/auth/AuthenticatedUser.java
+++ b/src/main/java/svsite/matzip/foody/global/auth/AuthenticatedUser.java
@@ -1,0 +1,16 @@
+package svsite.matzip.foody.global.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import svsite.matzip.foody.global.util.jwt.JwtTokenType;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AuthenticatedUser {
+  JwtTokenType value() default JwtTokenType.ACCESS;
+}
+

--- a/src/main/java/svsite/matzip/foody/global/auth/AuthenticatedUserResolver.java
+++ b/src/main/java/svsite/matzip/foody/global/auth/AuthenticatedUserResolver.java
@@ -1,0 +1,81 @@
+package svsite.matzip.foody.global.auth;
+
+import static svsite.matzip.foody.global.exception.errorCode.ErrorCodes.USER_NOT_FOUND;
+import static svsite.matzip.foody.global.util.jwt.JwtErrorMessages.REFRESH_TOKEN_INVALID;
+
+import io.jsonwebtoken.Claims;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.auth.repository.UserRepository;
+import svsite.matzip.foody.global.exception.support.CustomException;
+import svsite.matzip.foody.global.util.jwt.JwtTokenType;
+import svsite.matzip.foody.global.util.jwt.JwtUtil;
+import svsite.matzip.foody.global.util.jwt.exception.InvalidJwtTokenException;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticatedUserResolver implements HandlerMethodArgumentResolver {
+
+  private final JwtUtil jwtUtil;
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    AuthenticatedUser annotation = parameter.getParameterAnnotation(AuthenticatedUser.class);
+    return annotation != null && parameter.getParameterType().equals(User.class);
+  }
+
+  @Override
+  public @NonNull Object resolveArgument(@NonNull MethodParameter parameter,
+      @NonNull ModelAndViewContainer mavContainer,
+      @NonNull NativeWebRequest webRequest,
+      @NonNull WebDataBinderFactory binderFactory) {
+
+    // Authorization 헤더에서 토큰 추출
+    String token = webRequest.getHeader("Authorization");
+    if (token == null || !token.startsWith("Bearer ")) {
+      throw new RuntimeException("Authorization 헤더가 없거나 형식이 잘못되었습니다.");
+    }
+    token = token.substring(7);  // "Bearer " 제거
+
+    // JWT 검증 및 클레임 추출
+    Claims claims = jwtUtil.validateToken(token);
+    String email = claims.getSubject();
+
+    // 토큰 타입 검증
+    AuthenticatedUser annotation = parameter.getParameterAnnotation(AuthenticatedUser.class);
+    JwtTokenType requiredType = annotation.value();
+    JwtTokenType tokenType = JwtTokenType.valueOf((String) claims.get("type"));
+
+    if (requiredType != tokenType) {
+      throw new RuntimeException("Invalid token type. Expected: " + requiredType);
+    }
+
+    // 사용자 조회
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+    // RefreshToken 검증이 필요한 경우 추가 검증
+    if (requiredType == JwtTokenType.REFRESH) {
+      String hashedRefreshToken = user.getHashedRefreshToken();
+      if (hashedRefreshToken == null || hashedRefreshToken.isEmpty()) {
+        throw new InvalidJwtTokenException(REFRESH_TOKEN_INVALID);
+      }
+
+      if (!passwordEncoder.matches(token, hashedRefreshToken)) {
+        throw new CustomException(REFRESH_TOKEN_INVALID);
+      }
+    }
+
+    return user;
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/auth/AuthenticatedUserResolver.java
+++ b/src/main/java/svsite/matzip/foody/global/auth/AuthenticatedUserResolver.java
@@ -4,6 +4,7 @@ import static svsite.matzip.foody.global.exception.errorCode.ErrorCodes.USER_NOT
 import static svsite.matzip.foody.global.util.jwt.JwtErrorMessages.REFRESH_TOKEN_INVALID;
 
 import io.jsonwebtoken.Claims;
+import jakarta.annotation.Nullable;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -36,14 +37,14 @@ public class AuthenticatedUserResolver implements HandlerMethodArgumentResolver 
 
   @Override
   public @NonNull Object resolveArgument(@NonNull MethodParameter parameter,
-      @NonNull ModelAndViewContainer mavContainer,
+      @Nullable ModelAndViewContainer mavContainer,
       @NonNull NativeWebRequest webRequest,
-      @NonNull WebDataBinderFactory binderFactory) {
+      @Nullable  WebDataBinderFactory binderFactory) {
 
     // Authorization 헤더에서 토큰 추출
     String token = webRequest.getHeader("Authorization");
     if (token == null || !token.startsWith("Bearer ")) {
-      throw new RuntimeException("Authorization 헤더가 없거나 형식이 잘못되었습니다.");
+      throw new CustomException("Authorization 헤더가 없거나 형식이 잘못되었습니다.");
     }
     token = token.substring(7);  // "Bearer " 제거
 
@@ -57,7 +58,7 @@ public class AuthenticatedUserResolver implements HandlerMethodArgumentResolver 
     JwtTokenType tokenType = JwtTokenType.valueOf((String) claims.get("type"));
 
     if (requiredType != tokenType) {
-      throw new RuntimeException("Invalid token type. Expected: " + requiredType);
+      throw new CustomException("Invalid token type. Expected: " + requiredType);
     }
 
     // 사용자 조회

--- a/src/main/java/svsite/matzip/foody/global/config/SecurityConfig.java
+++ b/src/main/java/svsite/matzip/foody/global/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package svsite.matzip.foody.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/config/SwaggerConfig.java
+++ b/src/main/java/svsite/matzip/foody/global/config/SwaggerConfig.java
@@ -3,8 +3,13 @@ package svsite.matzip.foody.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.Arrays;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import svsite.matzip.foody.global.auth.AuthenticatedUser;
 
 @Configuration
 public class SwaggerConfig {
@@ -15,8 +20,24 @@ public class SwaggerConfig {
         .title("Foody API Document")
         .version("v0.0.1")
         .description("Foody 프로젝트 API 명세서입니다.");
+
     return new OpenAPI()
-        .components(new Components())
+        .components(new Components()
+            .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")))
+        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
         .info(info);
+  }
+
+  @Bean
+  public OperationCustomizer operationCustomizer() {
+    return (operation, handlerMethod) -> {
+      Arrays.stream(handlerMethod.getMethodParameters())
+          .filter(param -> param.hasParameterAnnotation(AuthenticatedUser.class))
+          .forEach(param -> operation.getParameters().clear());
+      return operation;
+    };
   }
 }

--- a/src/main/java/svsite/matzip/foody/global/config/SwaggerConfig.java
+++ b/src/main/java/svsite/matzip/foody/global/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package svsite.matzip.foody.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Info info = new Info()
+        .title("Foody API Document")
+        .version("v0.0.1")
+        .description("Foody 프로젝트 API 명세서입니다.");
+    return new OpenAPI()
+        .components(new Components())
+        .info(info);
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/config/WebConfig.java
+++ b/src/main/java/svsite/matzip/foody/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package svsite.matzip.foody.global.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import svsite.matzip.foody.global.auth.AuthenticatedUserResolver;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+  private final AuthenticatedUserResolver authenticatedUserResolver;
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(authenticatedUserResolver); // 커스텀 Resolver 추가
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/constant/Constant.java
+++ b/src/main/java/svsite/matzip/foody/global/constant/Constant.java
@@ -1,0 +1,5 @@
+package svsite.matzip.foody.global.constant;
+
+public class Constant {
+  public final static String EMAIL = "email";
+}

--- a/src/main/java/svsite/matzip/foody/global/util/jwt/JwtErrorMessages.java
+++ b/src/main/java/svsite/matzip/foody/global/util/jwt/JwtErrorMessages.java
@@ -7,6 +7,7 @@ public final class JwtErrorMessages {
   public static final String TOKEN_INVALID_SIGNATURE = "서명 검증에 실패한 JWT 토큰입니다.";
   public static final String TOKEN_INVALID = "유효하지 않은 JWT 토큰입니다.";
   public static final String TOKEN_HEADER_INVALID = "유효하지 않은 JWT 토큰 헤더입니다.";
+  public static final String REFRESH_TOKEN_INVALID = "유효하지 않은 리프레시 토큰 입니다.";
 
   private JwtErrorMessages() {}
 }

--- a/src/main/java/svsite/matzip/foody/global/util/jwt/JwtErrorMessages.java
+++ b/src/main/java/svsite/matzip/foody/global/util/jwt/JwtErrorMessages.java
@@ -1,0 +1,12 @@
+package svsite.matzip.foody.global.util.jwt;
+
+public final class JwtErrorMessages {
+  public static final String TOKEN_EXPIRED = "토큰이 만료되었습니다.";
+  public static final String TOKEN_UNSUPPORTED = "지원하지 않는 JWT 형식입니다.";
+  public static final String TOKEN_MALFORMED = "손상된 JWT 토큰입니다.";
+  public static final String TOKEN_INVALID_SIGNATURE = "서명 검증에 실패한 JWT 토큰입니다.";
+  public static final String TOKEN_INVALID = "유효하지 않은 JWT 토큰입니다.";
+  public static final String TOKEN_HEADER_INVALID = "유효하지 않은 JWT 토큰 헤더입니다.";
+
+  private JwtErrorMessages() {}
+}

--- a/src/main/java/svsite/matzip/foody/global/util/jwt/JwtTokenType.java
+++ b/src/main/java/svsite/matzip/foody/global/util/jwt/JwtTokenType.java
@@ -1,0 +1,5 @@
+package svsite.matzip.foody.global.util.jwt;
+
+public enum JwtTokenType {
+  ACCESS, REFRESH
+}

--- a/src/main/java/svsite/matzip/foody/global/util/jwt/JwtUtil.java
+++ b/src/main/java/svsite/matzip/foody/global/util/jwt/JwtUtil.java
@@ -82,13 +82,6 @@ public class JwtUtil {
     }
   }
 
-  private String parseBearerToken(String token) {
-    if (token == null || !token.startsWith(BEARER_TOKEN)) {
-      throw new InvalidJwtTokenException(JwtErrorMessages.TOKEN_HEADER_INVALID);
-    }
-    return token.replace(BEARER_TOKEN, "").trim();
-  }
-
   private Date calculateExpiration(long duration) {
     return new Date(System.currentTimeMillis() + duration);
   }

--- a/src/main/java/svsite/matzip/foody/global/util/jwt/JwtUtil.java
+++ b/src/main/java/svsite/matzip/foody/global/util/jwt/JwtUtil.java
@@ -1,0 +1,95 @@
+package svsite.matzip.foody.global.util.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import svsite.matzip.foody.global.util.jwt.exception.InvalidJwtTokenException;
+
+@Component
+public class JwtUtil {
+
+  private final long accessTokenExpiration;
+  private final long refreshTokenExpiration;
+  private final Key signingKey;
+  private static final String TYPE_CLAIM = "type";
+  private static final String EMAIL_CLAIM = "email";
+  private static final String BEARER_TOKEN = "Bearer ";
+
+  public JwtUtil(
+      @Value("${jwt.secret}") String secretKey,
+      @Value("${jwt.expiration.access-token}") long accessTokenExpiration,
+      @Value("${jwt.expiration.refresh-token}") long refreshTokenExpiration) {
+    this.accessTokenExpiration = accessTokenExpiration;
+    this.refreshTokenExpiration = refreshTokenExpiration;
+    byte[] decodedKey = Base64.getDecoder().decode(secretKey);
+    this.signingKey = Keys.hmacShaKeyFor(decodedKey);
+  }
+
+  public String generateAccessToken(Map<String, Object> payload) {
+    payload.put(TYPE_CLAIM, JwtTokenType.ACCESS);
+    String email = (String) payload.get(EMAIL_CLAIM);
+
+    return Jwts.builder()
+        .setClaims(payload)
+        .setSubject(email)
+        .setExpiration(calculateExpiration(accessTokenExpiration))
+        .signWith(signingKey, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  public String generateRefreshToken(Map<String, Object> payload) {
+    payload.put(TYPE_CLAIM, JwtTokenType.REFRESH.name());
+    String email = (String) payload.get(EMAIL_CLAIM);
+
+    return Jwts.builder()
+        .setClaims(payload)
+        .setSubject(email)
+        .setIssuedAt(new Date())
+        .setExpiration(calculateExpiration(refreshTokenExpiration))
+        .signWith(signingKey, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  // 토큰 검증
+  public Claims validateToken(String token) {
+    try {
+      return Jwts.parserBuilder()
+          .setSigningKey(signingKey)
+          .build()
+          .parseClaimsJws(token)
+          .getBody();
+    } catch (ExpiredJwtException e) {
+      throw new InvalidJwtTokenException(JwtErrorMessages.TOKEN_EXPIRED, e);
+    } catch (UnsupportedJwtException e) {
+      throw new InvalidJwtTokenException(JwtErrorMessages.TOKEN_UNSUPPORTED, e);
+    } catch (MalformedJwtException e) {
+      throw new InvalidJwtTokenException(JwtErrorMessages.TOKEN_MALFORMED, e);
+    } catch (SecurityException e) {
+      throw new InvalidJwtTokenException(JwtErrorMessages.TOKEN_INVALID_SIGNATURE, e);
+    } catch (JwtException e) {
+      throw new InvalidJwtTokenException(JwtErrorMessages.TOKEN_INVALID, e);
+    }
+  }
+
+  private String parseBearerToken(String token) {
+    if (token == null || !token.startsWith(BEARER_TOKEN)) {
+      throw new InvalidJwtTokenException(JwtErrorMessages.TOKEN_HEADER_INVALID);
+    }
+    return token.replace(BEARER_TOKEN, "").trim();
+  }
+
+  private Date calculateExpiration(long duration) {
+    return new Date(System.currentTimeMillis() + duration);
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/util/jwt/exception/InvalidJwtTokenException.java
+++ b/src/main/java/svsite/matzip/foody/global/util/jwt/exception/InvalidJwtTokenException.java
@@ -1,0 +1,27 @@
+package svsite.matzip.foody.global.util.jwt.exception;
+
+import svsite.matzip.foody.global.exception.support.CustomException;
+import svsite.matzip.foody.global.exception.support.ErrorCode;
+
+public class InvalidJwtTokenException extends CustomException {
+
+  public InvalidJwtTokenException() {
+  }
+
+  public InvalidJwtTokenException(String message) {
+    super(message);
+  }
+
+  public InvalidJwtTokenException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public InvalidJwtTokenException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public InvalidJwtTokenException(ErrorCode errorCode,
+      Throwable cause) {
+    super(errorCode, cause);
+  }
+}

--- a/src/test/java/svsite/matzip/foody/domain/auth/ControllerTestSupport.java
+++ b/src/test/java/svsite/matzip/foody/domain/auth/ControllerTestSupport.java
@@ -1,0 +1,21 @@
+package svsite.matzip.foody.domain.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import svsite.matzip.foody.domain.auth.api.AuthController;
+import svsite.matzip.foody.domain.auth.service.AuthService;
+
+@WebMvcTest(controllers = {
+    AuthController.class,
+})
+public abstract class ControllerTestSupport {
+  @Autowired
+  protected MockMvc mockMvc;
+  @Autowired
+  protected ObjectMapper objectMapper;
+  @MockBean
+  protected AuthService authService;
+}

--- a/src/test/java/svsite/matzip/foody/domain/auth/ControllerTestSupport.java
+++ b/src/test/java/svsite/matzip/foody/domain/auth/ControllerTestSupport.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import svsite.matzip.foody.domain.auth.api.AuthController;
 import svsite.matzip.foody.domain.auth.service.AuthService;
+import svsite.matzip.foody.global.auth.AuthenticatedUserResolver;
 
 @WebMvcTest(controllers = {
     AuthController.class,
@@ -18,4 +19,6 @@ public abstract class ControllerTestSupport {
   protected ObjectMapper objectMapper;
   @MockBean
   protected AuthService authService;
+  @MockBean
+  protected AuthenticatedUserResolver authenticatedUserResolver;
 }

--- a/src/test/java/svsite/matzip/foody/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/auth/api/AuthControllerTest.java
@@ -1,31 +1,114 @@
 package svsite.matzip.foody.domain.auth.api;
 
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
+import svsite.matzip.foody.domain.auth.ControllerTestSupport;
 import svsite.matzip.foody.domain.auth.api.dto.request.AuthRequestDto;
-import svsite.matzip.foody.domain.auth.service.AuthService;
+import svsite.matzip.foody.domain.auth.api.dto.response.TokenResponseDto;
+import svsite.matzip.foody.global.exception.errorCode.ErrorCodes;
+import svsite.matzip.foody.global.exception.support.CustomException;
 
-import static org.mockito.Mockito.when;
-import static org.assertj.core.api.Assertions.assertThat;
-
-class AuthControllerTest {
-
-  private final AuthService authService = Mockito.mock(AuthService.class);
-  private final AuthController authController = new AuthController(authService);
+class AuthControllerTest extends ControllerTestSupport {
 
   @Test
-  void signup_shouldReturnUserId_whenValidRequest() {
+  @DisplayName("회원가입 성공 시 200 OK와 userId를 반환한다.")
+  void signup_success() throws Exception {
     // given
-    AuthRequestDto requestDto = new AuthRequestDto("test@example.com", "password123");
-    when(authService.signup(requestDto)).thenReturn(1L);
+    AuthRequestDto requestDto = new AuthRequestDto("test@example.com", "12345678");
+    given(authService.signup(any(AuthRequestDto.class))).willReturn(1L);
 
-    // when
-    ResponseEntity<Long> response = authController.signup(requestDto);
+    // when & then
+    mockMvc.perform(post("/auth/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isOk())
+        .andExpect(content().string("1"));
+  }
 
-    // then
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody()).isEqualTo(1L);
+  @Test
+  @DisplayName("중복된 이메일인 경우 409 CONFLICT를 반환한다.")
+  void signup_duplicateEmail() throws Exception {
+    // given
+    AuthRequestDto requestDto = new AuthRequestDto("exists@example.com", "12345678");
+    doThrow(new CustomException(ErrorCodes.USER_EMAIL_DUPLICATE))
+        .when(authService).signup(any(AuthRequestDto.class));
+
+    // when & then
+    mockMvc.perform(post("/auth/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isConflict()); // 409
+  }
+
+  @Test
+  @DisplayName("유효성 검증에 걸리면 400 BAD REQUEST를 반환한다.")
+  void signup_invalidRequest() throws Exception {
+    AuthRequestDto invalidDto = new AuthRequestDto("", "");
+
+    // when & then
+    mockMvc.perform(post("/auth/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(invalidDto)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("로그인 성공 시 200 OK와 토큰 정보를 반환한다")
+  void signin_success() throws Exception {
+    // given
+    AuthRequestDto requestDto = new AuthRequestDto("test@example.com", "12345678");
+    TokenResponseDto tokenResponse = new TokenResponseDto("mockAccessToken", "mockRefreshToken");
+
+    given(authService.signin(any(AuthRequestDto.class))).willReturn(tokenResponse);
+
+    // when & then
+    mockMvc.perform(post("/auth/signin")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken", is("mockAccessToken")))
+        .andExpect(jsonPath("$.refreshToken", is("mockRefreshToken")));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자인 경우 404 NOT FOUND 반환")
+  void signin_userNotFound() throws Exception {
+    // given
+    AuthRequestDto requestDto = new AuthRequestDto("notfound@example.com", "12345678");
+
+    doThrow(new CustomException(ErrorCodes.USER_NOT_FOUND))
+        .when(authService).signin(any(AuthRequestDto.class));
+
+    // when & then
+    mockMvc.perform(post("/auth/signin")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isNotFound()); // 404
+  }
+
+  @Test
+  @DisplayName("비밀번호 불일치 등 잘못된 요청 시 400 BAD REQUEST 반환")
+  void signin_wrongPassword() throws Exception {
+    // given
+    AuthRequestDto requestDto = new AuthRequestDto("test@example.com", "wrongpw");
+
+    doThrow(new CustomException(ErrorCodes.USER_WRONG_PASSWORD))
+        .when(authService).signin(any(AuthRequestDto.class));
+
+    // when & then
+    mockMvc.perform(post("/auth/signin")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isBadRequest()); // 400
   }
 }

--- a/src/test/java/svsite/matzip/foody/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/auth/api/AuthControllerTest.java
@@ -1,0 +1,31 @@
+package svsite.matzip.foody.domain.auth.api;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import svsite.matzip.foody.domain.auth.api.dto.request.AuthRequestDto;
+import svsite.matzip.foody.domain.auth.service.AuthService;
+
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthControllerTest {
+
+  private final AuthService authService = Mockito.mock(AuthService.class);
+  private final AuthController authController = new AuthController(authService);
+
+  @Test
+  void signup_shouldReturnUserId_whenValidRequest() {
+    // given
+    AuthRequestDto requestDto = new AuthRequestDto("test@example.com", "password123");
+    when(authService.signup(requestDto)).thenReturn(1L);
+
+    // when
+    ResponseEntity<Long> response = authController.signup(requestDto);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo(1L);
+  }
+}

--- a/src/test/java/svsite/matzip/foody/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,74 @@
+package svsite.matzip.foody.domain.auth.service;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+import svsite.matzip.foody.domain.auth.api.dto.request.AuthRequestDto;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.auth.repository.UserRepository;
+import svsite.matzip.foody.global.exception.errorCode.ErrorCodes;
+import svsite.matzip.foody.global.exception.support.CustomException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+class AuthServiceTest {
+
+  private final UserRepository userRepository = Mockito.mock(UserRepository.class);
+  private final PasswordEncoder passwordEncoder = Mockito.mock(PasswordEncoder.class);
+  private final AuthService authService = new AuthService(userRepository, passwordEncoder);
+
+  /**
+   * 정상 회원가입 테스트
+   */
+  @Test
+  void signup_success() {
+    // given
+    AuthRequestDto authRequestDto = new AuthRequestDto("test@example.com", "password123");
+
+    when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.empty());
+    when(passwordEncoder.encode("password123")).thenReturn("encodedPassword");
+
+    doAnswer(invocation -> {
+      User user = invocation.getArgument(0);
+      ReflectionTestUtils.setField(user, "id", 1L);
+      return user;
+    }).when(userRepository).save(any(User.class));
+
+    // when
+    Long returnedId = authService.signup(authRequestDto);
+
+    // then
+    assertNotNull(returnedId, "저장된 User의 id는 null 이 아니어야 합니다.");
+    assertEquals(1L, returnedId, "저장된 User의 id가 예상한 값이어야 합니다.");
+    verify(userRepository).findByEmail("test@example.com");
+    verify(passwordEncoder).encode("password123");
+    verify(userRepository).save(any(User.class));
+  }
+
+  /**
+   * 중복 이메일로 회원가입 시 예외 발생 테스트
+   */
+  @Test
+  void signup_duplicateEmail_throwsException() {
+    // given
+    AuthRequestDto authRequestDto = new AuthRequestDto("duplicate@example.com", "password123");
+    User existingUser = User.builder().build();
+    when(userRepository.findByEmail("duplicate@example.com")).thenReturn(Optional.of(existingUser));
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      authService.signup(authRequestDto);
+    });
+    assertEquals(ErrorCodes.USER_EMAIL_DUPLICATE, exception.getErrorCode());
+    verify(userRepository).findByEmail("duplicate@example.com");
+    verify(passwordEncoder, never()).encode(anyString());
+    verify(userRepository, never()).save(any(User.class));
+  }
+}

--- a/src/test/java/svsite/matzip/foody/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/auth/service/AuthServiceTest.java
@@ -1,32 +1,39 @@
 package svsite.matzip.foody.domain.auth.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import java.util.Optional;
 import org.springframework.test.util.ReflectionTestUtils;
 import svsite.matzip.foody.domain.auth.api.dto.request.AuthRequestDto;
+import svsite.matzip.foody.domain.auth.api.dto.response.TokenResponseDto;
 import svsite.matzip.foody.domain.auth.entity.User;
 import svsite.matzip.foody.domain.auth.repository.UserRepository;
 import svsite.matzip.foody.global.exception.errorCode.ErrorCodes;
 import svsite.matzip.foody.global.exception.support.CustomException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import svsite.matzip.foody.global.util.jwt.JwtUtil;
 
 
 class AuthServiceTest {
 
   private final UserRepository userRepository = Mockito.mock(UserRepository.class);
   private final PasswordEncoder passwordEncoder = Mockito.mock(PasswordEncoder.class);
-  private final AuthService authService = new AuthService(userRepository, passwordEncoder);
+  private final JwtUtil jwtUtil = Mockito.mock(JwtUtil.class);
+  private final AuthService authService = new AuthService(userRepository, passwordEncoder, jwtUtil);
 
-  /**
-   * 정상 회원가입 테스트
-   */
+  @DisplayName("정상 회원가입")
   @Test
   void signup_success() {
     // given
@@ -52,9 +59,7 @@ class AuthServiceTest {
     verify(userRepository).save(any(User.class));
   }
 
-  /**
-   * 중복 이메일로 회원가입 시 예외 발생 테스트
-   */
+  @DisplayName("중복 이메일로 회원가입시 예외 발생")
   @Test
   void signup_duplicateEmail_throwsException() {
     // given
@@ -70,5 +75,63 @@ class AuthServiceTest {
     verify(userRepository).findByEmail("duplicate@example.com");
     verify(passwordEncoder, never()).encode(anyString());
     verify(userRepository, never()).save(any(User.class));
+  }
+
+  @DisplayName("로그인 성공")
+  @Test
+  void signin_success() {
+    // given
+    AuthRequestDto authRequestDto = new AuthRequestDto("test@example.com", "password123");
+    User user = User.builder().password("encodedPassword").build();
+    when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
+    when(jwtUtil.generateAccessToken(anyMap())).thenReturn("accessToken");
+    when(jwtUtil.generateRefreshToken(anyMap())).thenReturn("refreshToken");
+
+    // when
+    TokenResponseDto tokenResponse = authService.signin(authRequestDto);
+
+    // then
+    assertNotNull(tokenResponse, "토큰 응답이 null이 아니어야 합니다.");
+    assertEquals("accessToken", tokenResponse.accessToken(), "Access token이 예상한 값이어야 합니다.");
+    assertEquals("refreshToken", tokenResponse.refreshToken(), "Refresh token이 예상한 값이어야 합니다.");
+    verify(userRepository).findByEmail("test@example.com");
+    verify(passwordEncoder).matches("password123", "encodedPassword");
+    verify(jwtUtil).generateAccessToken(anyMap());
+    verify(jwtUtil).generateRefreshToken(anyMap());
+  }
+
+  @DisplayName("로그인 실패 - 잘못된 비밀번호")
+  @Test
+  void signin_wrongPassword_throwsException() {
+    // given
+    AuthRequestDto authRequestDto = new AuthRequestDto("test@example.com", "wrongPassword");
+    User user = User.builder().password("encodedPassword").build();
+    when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches("wrongPassword", "encodedPassword")).thenReturn(false);
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () -> authService.signin(authRequestDto));
+    assertEquals(ErrorCodes.USER_WRONG_PASSWORD, exception.getErrorCode());
+    verify(userRepository).findByEmail("test@example.com");
+    verify(passwordEncoder).matches("wrongPassword", "encodedPassword");
+    verify(jwtUtil, never()).generateAccessToken(anyMap());
+    verify(jwtUtil, never()).generateRefreshToken(anyMap());
+  }
+
+  @DisplayName("로그인 실패 - 사용자가 존재하지 않음")
+  @Test
+  void signin_emailNotFound_throwsException() {
+    // given
+    AuthRequestDto authRequestDto = new AuthRequestDto("notfound@example.com", "password123");
+    when(userRepository.findByEmail("notfound@example.com")).thenReturn(Optional.empty());
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () -> authService.signin(authRequestDto));
+    assertEquals(ErrorCodes.USER_NOT_FOUND, exception.getErrorCode());
+    verify(userRepository).findByEmail("notfound@example.com");
+    verify(passwordEncoder, never()).matches(anyString(), anyString());
+    verify(jwtUtil, never()).generateAccessToken(anyMap());
+    verify(jwtUtil, never()).generateRefreshToken(anyMap());
   }
 }

--- a/src/test/java/svsite/matzip/foody/global/auth/AuthenticatedUserResolverTest.java
+++ b/src/test/java/svsite/matzip/foody/global/auth/AuthenticatedUserResolverTest.java
@@ -1,0 +1,153 @@
+package svsite.matzip.foody.global.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static svsite.matzip.foody.global.exception.errorCode.ErrorCodes.USER_NOT_FOUND;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.auth.repository.UserRepository;
+import svsite.matzip.foody.global.exception.support.CustomException;
+import svsite.matzip.foody.global.util.jwt.JwtTokenType;
+import svsite.matzip.foody.global.util.jwt.JwtUtil;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticatedUserResolverTest {
+
+  @InjectMocks
+  private AuthenticatedUserResolver resolver;
+
+  @Mock
+  private JwtUtil jwtUtil;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @Mock
+  private NativeWebRequest webRequest;
+
+  @Mock
+  private ModelAndViewContainer mavContainer;  // 추가
+  @Mock
+  private WebDataBinderFactory binderFactory;  // 추가
+
+  private MethodParameter methodParameter;
+
+  @BeforeEach
+  void setup() throws NoSuchMethodException {
+    methodParameter = new MethodParameter(
+        this.getClass().getDeclaredMethod("dummyMethod", User.class), 0
+    );
+  }
+
+  private void dummyMethod(@AuthenticatedUser(JwtTokenType.REFRESH) User user) {
+  }
+
+
+  @Test
+  @DisplayName("토큰이 없을 경우 CustomException을 발생시킨다.")
+  void resolveArgument_missingToken() {
+    // given
+    when(webRequest.getHeader("Authorization")).thenReturn(null);
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () ->
+        resolver.resolveArgument(methodParameter, null, webRequest, null)
+    );
+    assertEquals("Authorization 헤더가 없거나 형식이 잘못되었습니다.", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("잘못된 형식의 토큰이 들어오면 CustomException을 발생시킨다.")
+  void resolveArgument_invalidTokenFormat() {
+    // given
+    when(webRequest.getHeader("Authorization")).thenReturn("InvalidToken");
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () ->
+        resolver.resolveArgument(methodParameter, null, webRequest, null)
+    );
+    assertEquals("Authorization 헤더가 없거나 형식이 잘못되었습니다.", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("유효한 토큰과 올바른 사용자 정보가 있을 경우 User 객체를 반환한다.")
+  void resolveArgument_success() {
+    // given
+    String token = "validToken";
+    Claims claims = Jwts.claims().setSubject("test@example.com");
+    claims.put("type", JwtTokenType.REFRESH.name());
+
+    when(webRequest.getHeader("Authorization")).thenReturn("Bearer " + token);
+    when(jwtUtil.validateToken(token)).thenReturn(claims);
+    when(userRepository.findByEmail("test@example.com")).thenReturn(
+        Optional.of(User.builder()
+            .email("test@example.com")
+            .hashedRefreshToken("encodedValidRefreshToken")  // RefreshToken 설정
+            .build())
+    );
+    when(passwordEncoder.matches(token, "encodedValidRefreshToken")).thenReturn(true);  // 매칭 설정
+
+    // when
+    User result = (User) resolver.resolveArgument(methodParameter, null, webRequest, null);
+
+    // then
+    assertNotNull(result);
+    assertEquals("test@example.com", result.getEmail());
+  }
+
+
+  @Test
+  @DisplayName("토큰 타입이 잘못된 경우 CustomException을 발생시킨다.")
+  void resolveArgument_invalidTokenType() {
+    // given
+    String token = "validToken";
+    Claims claims = Jwts.claims().setSubject("test@example.com");
+    claims.put("type", JwtTokenType.ACCESS.name());  // 잘못된 타입
+
+    when(webRequest.getHeader("Authorization")).thenReturn("Bearer " + token);
+    when(jwtUtil.validateToken(token)).thenReturn(claims);
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () ->
+        resolver.resolveArgument(methodParameter, null, webRequest, null)
+    );
+    assertEquals("Invalid token type. Expected: REFRESH", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("사용자가 존재하지 않으면 CustomException을 발생시킨다.")
+  void resolveArgument_userNotFound() {
+    // given
+    String token = "validToken";
+    Claims claims = Jwts.claims().setSubject("notfound@example.com");
+    claims.put("type", JwtTokenType.REFRESH.name());
+
+    when(webRequest.getHeader("Authorization")).thenReturn("Bearer " + token);
+    when(jwtUtil.validateToken(token)).thenReturn(claims);
+    when(userRepository.findByEmail("notfound@example.com")).thenReturn(Optional.empty());
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () ->
+        resolver.resolveArgument(methodParameter, null, webRequest, null)
+    );
+    assertEquals(USER_NOT_FOUND, exception.getErrorCode());
+  }
+}


### PR DESCRIPTION
### **1. PR 개요**  
회원가입, 로그인, 토큰 재발급 기능을 구현하였습니다.

---

### **2. 주요 변경 사항 및 설명**

##### **1) 비밀번호 암호화를 위한 `spring-security-crypto` 의존성 추가**  
- `PasswordEncoder` 인터페이스의 구현체로 `BCryptPasswordEncoder`를 채택하였습니다.
```gradle
// 암호화 의존성
implementation 'org.springframework.security:spring-security-crypto:6.0.0'
```

##### **2) JWT 기반 인증/인가 방식 적용**  
- `accessToken`을 활용한 `stateless` 방식으로 인증을 처리합니다.
- `refreshToken`은 데이터베이스에 단방향으로 암호화하여 저장합니다.  
  - 이 방식은 `stateless` 특성을 일부 잃지만, 보안이 강화된다는 이점이 있습니다.

##### **3) 로그 파일의 압축 및 `.gitignore` 설정 추가**  
- 로그 파일이 10MB를 초과하면 자동으로 압축된 파일을 생성합니다.
- 날짜와 인덱스를 기반으로 로그 파일을 관리하며, 최대 30일간 보관합니다.
```gitignore
# 압축된 로그 파일 무시
*.gz
```

##### **4) Swagger 설정 추가**  
- API 문서화를 통해 백엔드와 프론트엔드 간 협업을 원활히 하기 위해 Swagger(OpenAPI)를 설정하였습니다.

##### **5) JWT 관련 의존성 추가**  
- JWT 기반 토큰 처리를 위해 필요한 3가지 의존성을 추가하였습니다.
```gradle
// JWT 의존성
implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
```

---

### **3. 설계 의도 및 고려 사항**  
- Refresh 토큰은 단방향 암호화를 통해 저장하여 보안을 강화하였습니다.
- 토큰 인증 과정에서 JWT의 유효성 검증을 철저히 수행합니다.
- Swagger 문서화를 통해 API 인터페이스 명세 제공으로 개발자 간 소통을 개선하였습니다.

---

### **4. 테스트 및 검증**  
- 각 기능에 대한 단위 테스트를 수행하여 정상 동작을 확인했습니다.
  - **회원가입** 테스트
  - **로그인** 테스트 (성공 및 실패 케이스)
  - **토큰 재발급** 테스트

---

### **5. 기타 참고 사항**  
- PR에서 처리된 기능들은 모두 백엔드 API 명세에 명확히 반영되었습니다.

---

**This closes #13**  

이렇게 작성하면 어떨까요? 추가하거나 수정할 내용이 있다면 알려주세요!