### PR TITLE
게시글 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,3 +52,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+compileJava {
+    options.compilerArgs += ['-parameters']
+}

--- a/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
@@ -1,17 +1,23 @@
 package svsite.matzip.foody.domain.post.api;
 
+import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.post.api.dto.request.CreatePostDto;
 import svsite.matzip.foody.domain.post.api.dto.response.MarkersResponseDto;
+import svsite.matzip.foody.domain.post.api.dto.response.PostResponseDto;
 import svsite.matzip.foody.domain.post.service.PostService;
 import svsite.matzip.foody.global.auth.AuthenticatedUser;
 
@@ -28,5 +34,13 @@ public class PostController {
   @GetMapping("/markers/my")
   public ResponseEntity<List<MarkersResponseDto>> getAllMarkers(@AuthenticatedUser User user) {
     return ResponseEntity.status(OK).body(postService.getAllMarkers(user));
+  }
+
+  @Operation(summary = "맛집 위치 및 설명에 대한 글을 등록"
+      , description = "사용자는 맛집 위치 및 설명에 대한 글을 등록합니다.")
+  @PostMapping("/posts")
+  public ResponseEntity<PostResponseDto> createPost(@RequestBody @Valid CreatePostDto createPostDto
+      , @AuthenticatedUser User user) {
+    return ResponseEntity.status(CREATED).body(postService.createPost(createPostDto, user));
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
@@ -4,6 +4,8 @@ import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -11,11 +13,14 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import svsite.matzip.foody.domain.auth.entity.User;
 import svsite.matzip.foody.domain.post.api.dto.request.CreatePostDto;
+import svsite.matzip.foody.domain.post.api.dto.request.UpdatePostDto;
 import svsite.matzip.foody.domain.post.api.dto.response.MarkersResponseDto;
 import svsite.matzip.foody.domain.post.api.dto.response.PostResponseDto;
 import svsite.matzip.foody.domain.post.service.PostService;
@@ -42,5 +47,20 @@ public class PostController {
   public ResponseEntity<PostResponseDto> createPost(@RequestBody @Valid CreatePostDto createPostDto
       , @AuthenticatedUser User user) {
     return ResponseEntity.status(CREATED).body(postService.createPost(createPostDto, user));
+  }
+
+  @Operation(summary = "맛집 게시글 수정"
+      , description = "사용자가 등록한 맛집 게시글을 수정합니다."
+      , security = @SecurityRequirement(name = "bearerAuth"))
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "게시글 수정 성공"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
+  @PatchMapping("/posts/{id}")
+  public ResponseEntity<PostResponseDto>updatePost(@PathVariable("id") long id
+      , @RequestBody @Valid UpdatePostDto updatePostDto
+      , @AuthenticatedUser User user) {
+    return ResponseEntity.status(OK).body(postService.updatePost(id, updatePostDto, user));
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
@@ -107,4 +107,25 @@ public class PostController {
   ) {
     return ResponseEntity.ok(postService.getPosts(PageRequest.of(page, size), user));
   }
+
+  @Operation(
+      summary = "게시글 단건 조회",
+      description = "사용자가 등록한 특정 게시글을 ID로 조회합니다.",
+      security = @SecurityRequirement(name = "bearerAuth")
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "게시글 조회 성공"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글"),
+      @ApiResponse(responseCode = "401", description = "인증 실패"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
+  @GetMapping("/posts/{id}")
+  public ResponseEntity<PostResponseDto> getPostById(
+      @Parameter(description = "조회할 게시글 ID", example = "1", required = true)
+      @PathVariable("id") long id,
+
+      @AuthenticatedUser User user
+  ) {
+    return ResponseEntity.ok(postService.getPostById(id, user));
+  }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
@@ -1,0 +1,32 @@
+package svsite.matzip.foody.domain.post.api;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.post.api.dto.response.MarkersResponseDto;
+import svsite.matzip.foody.domain.post.service.PostService;
+import svsite.matzip.foody.global.auth.AuthenticatedUser;
+
+@Tag(name = "Post", description = "맛집 게시글 관련 API")
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+
+  private final PostService postService;
+
+  @Operation(summary = "내가 등록한 맛집 마커 리스트 조회"
+      , description = "사용자가 등록한 모든 맛집 좌표(마커)를 조회합니다."
+      , security = @SecurityRequirement(name = "bearerAuth"))
+  @GetMapping("/markers/my")
+  public ResponseEntity<List<MarkersResponseDto>> getAllMarkers(@AuthenticatedUser User user) {
+    return ResponseEntity.status(OK).body(postService.getAllMarkers(user));
+  }
+}

--- a/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -128,4 +129,28 @@ public class PostController {
   ) {
     return ResponseEntity.ok(postService.getPostById(id, user));
   }
+
+  @Operation(
+      summary = "해당 연월의 맛집 게시글 목록 조회",
+      description = "사용자가 등록한 맛집 게시글들을 지정한 연도와 월에 따라 일자별로 그룹화하여 조회합니다.",
+      security = @SecurityRequirement(name = "bearerAuth")
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+      @ApiResponse(responseCode = "401", description = "인증 실패")
+  })
+  @GetMapping("/posts")
+  public Map<Integer, List<PostResponseDto>> getPostsByMonth(
+      @Parameter(description = "조회할 연도 (YYYY 형식)", example = "2025", required = true)
+      @RequestParam("year") int year,
+
+      @Parameter(description = "조회할 월 (1~12)", example = "2", required = true)
+      @RequestParam("month") int month,
+
+      @AuthenticatedUser User user
+  ) {
+    return postService.getPostsByMonth(year, month, user);
+  }
+
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/PostController.java
@@ -1,22 +1,29 @@
 package svsite.matzip.foody.domain.post.api;
 
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import svsite.matzip.foody.domain.auth.entity.User;
 import svsite.matzip.foody.domain.post.api.dto.request.CreatePostDto;
@@ -42,7 +49,8 @@ public class PostController {
   }
 
   @Operation(summary = "맛집 위치 및 설명에 대한 글을 등록"
-      , description = "사용자는 맛집 위치 및 설명에 대한 글을 등록합니다.")
+      , description = "사용자는 맛집 위치 및 설명에 대한 글을 등록합니다."
+      , security = @SecurityRequirement(name = "bearerAuth"))
   @PostMapping("/posts")
   public ResponseEntity<PostResponseDto> createPost(@RequestBody @Valid CreatePostDto createPostDto
       , @AuthenticatedUser User user) {
@@ -58,9 +66,45 @@ public class PostController {
       @ApiResponse(responseCode = "400", description = "잘못된 요청")
   })
   @PatchMapping("/posts/{id}")
-  public ResponseEntity<PostResponseDto>updatePost(@PathVariable("id") long id
+  public ResponseEntity<PostResponseDto> updatePost(@PathVariable("id") long id
       , @RequestBody @Valid UpdatePostDto updatePostDto
       , @AuthenticatedUser User user) {
     return ResponseEntity.status(OK).body(postService.updatePost(id, updatePostDto, user));
+  }
+
+  @Operation(summary = "맛집 게시글 삭제",
+      description = "사용자가 등록한 맛집 게시글을 삭제합니다.",
+      security = @SecurityRequirement(name = "bearerAuth"))
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "게시글 삭제 성공"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
+  @DeleteMapping("/posts/{id}")
+  public ResponseEntity<Void> deletePost(@PathVariable("id") long id
+      , @AuthenticatedUser User user) {
+    postService.deletePost(id, user);
+    return ResponseEntity.status(NO_CONTENT).body(null);
+  }
+
+  @Operation(
+      summary = "내가 등록한 맛집 게시글 목록 조회",
+      description = "사용자가 등록한 모든 맛집 게시글 목록을 페이지 단위로 조회합니다.",
+      security = @SecurityRequirement(name = "bearerAuth")
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+      @ApiResponse(responseCode = "401", description = "인증 실패")
+  })
+  @GetMapping("/posts/my")
+  public ResponseEntity<Page<PostResponseDto>> getPosts(
+      @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+      @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+      @Parameter(description = "페이지 당 게시글 개수", example = "10")
+      @RequestParam(defaultValue = "10") @PositiveOrZero int size,
+      @AuthenticatedUser User user
+  ) {
+    return ResponseEntity.ok(postService.getPosts(PageRequest.of(page, size), user));
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/api/dto/request/CreatePostDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/dto/request/CreatePostDto.java
@@ -1,0 +1,63 @@
+package svsite.matzip.foody.domain.post.api.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import svsite.matzip.foody.domain.post.entity.MarkerColor;
+
+
+@Schema(description = "게시글 생성 요청 DTO")
+public record CreatePostDto(
+
+    @Schema(description = "위도 값 (최대 소수점 6자리, 범위: -90 ~ 90)", example = "37.566500")
+    @NotNull(message = "위도 값은 필수입니다.")
+    @DecimalMin(value = "-90.000000", inclusive = true, message = "위도는 -90 이상이어야 합니다.")
+    @DecimalMax(value = "90.000000", inclusive = true, message = "위도는 90 이하이어야 합니다.")
+    BigDecimal latitude,
+
+    @Schema(description = "경도 값 (최대 소수점 6자리, 범위: -180 ~ 180)", example = "126.978000")
+    @NotNull(message = "경도 값은 필수입니다.")
+    @DecimalMin(value = "-180.000000", inclusive = true, message = "경도는 -180 이상이어야 합니다.")
+    @DecimalMax(value = "180.000000", inclusive = true, message = "경도는 180 이하이어야 합니다.")
+    BigDecimal longitude,
+
+    @Schema(description = "마커 색상", example = "RED")
+    @NotNull(message = "마커 색상은 필수입니다.")
+    MarkerColor color,
+
+    @Schema(description = "주소 (최대 255자)", example = "서울특별시 강남구 테헤란로 123")
+    @Size(max = 255, message = "주소는 최대 255자까지 입력 가능합니다.")
+    String address,
+
+    @Schema(description = "제목 (최대 100자)", example = "맛집 추천")
+    @NotEmpty(message = "제목은 필수입니다.")
+    @Size(max = 100, message = "제목은 최대 100자까지 입력 가능합니다.")
+    String title,
+
+    @Schema(description = "설명 (최소 10자, 최대 1000자)", example = "여기는 정말 맛있는 음식점입니다.")
+    @NotEmpty(message = "설명은 필수입니다.")
+    @Size(max = 1000, message = "설명은 최소 10자, 최대 1000자까지 입력 가능합니다.")
+    String description,
+
+    @Schema(description = "날짜 및 시간 (형식: yyyy-MM-dd HH:mm:ss)", example = "2025-02-07 18:30:00")
+    @NotNull(message = "날짜는 필수입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", shape = JsonFormat.Shape.STRING)
+    LocalDateTime date,
+
+    @Schema(description = "점수 (0 ~ 10)", example = "8")
+    @Min(value = 0, message = "점수는 최소 0이어야 합니다.")
+    @Max(value = 10, message = "점수는 최대 10이어야 합니다.")
+    Integer score,
+
+    @Schema(description = "이미지 URI 목록 (각 URI는 최대 255자)", example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]")
+    List<@Size(max = 255, message = "이미지 URI는 최대 255자까지 입력 가능합니다.") String> imageUris
+) {}

--- a/src/main/java/svsite/matzip/foody/domain/post/api/dto/request/UpdatePostDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/dto/request/UpdatePostDto.java
@@ -1,0 +1,38 @@
+package svsite.matzip.foody.domain.post.api.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import svsite.matzip.foody.domain.post.entity.MarkerColor;
+
+@Schema(description = "맛집 글 수정 요청 DTO")
+public record UpdatePostDto(
+
+    @Schema(description = "마커 색상", example = "RED", requiredMode = REQUIRED)
+    @NotNull(message = "마커 색상은 필수입니다.")
+    MarkerColor color,
+
+    @Schema(description = "맛집 글 제목 (최대 100자)", example = "맛집 소개", requiredMode = REQUIRED)
+    @NotEmpty(message = "제목은 필수입니다.")
+    String title,
+
+    @Schema(description = "맛집 글 설명 (최대 1000자)", example = "정말 맛있는 집입니다!", requiredMode = REQUIRED)
+    @NotEmpty(message = "설명은 필수입니다.")
+    String description,
+
+    @Schema(description = "방문 날짜 및 시간", example = "2025-02-08 12:00:00", requiredMode = REQUIRED)
+    @NotNull(message = "날짜는 필수입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", shape = JsonFormat.Shape.STRING)
+    LocalDateTime date,
+
+    @Schema(description = "맛집 점수 (0 ~ 10)", example = "9")
+    @Min(value = 0, message = "점수는 최소 0이어야 합니다.")
+    @Max(value = 10, message = "점수는 최대 10이어야 합니다.")
+    Integer score
+) {}

--- a/src/main/java/svsite/matzip/foody/domain/post/api/dto/response/MarkersResponseDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/dto/response/MarkersResponseDto.java
@@ -1,0 +1,37 @@
+package svsite.matzip.foody.domain.post.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import lombok.Builder;
+import svsite.matzip.foody.domain.post.entity.MarkerColor;
+import svsite.matzip.foody.domain.post.repository.dto.PostMarkersQueryDto;
+
+@Schema(description = "맛집 마커 정보를 나타내는 응답 DTO")
+@Builder
+public record MarkersResponseDto(
+    @Schema(description = "마커 ID", example = "1")
+    Long id,
+
+    @Schema(description = "마커 위도 좌표", example = "37.566500")
+    BigDecimal latitude,
+
+    @Schema(description = "마커 경도 좌표", example = "126.978000")
+    BigDecimal longitude,
+
+    @Schema(description = "마커 색상", example = "RED")
+    MarkerColor color,
+
+    @Schema(description = "마커 점수", example = "10")
+    Integer score
+) {
+
+  public static MarkersResponseDto from(PostMarkersQueryDto dto) {
+    return MarkersResponseDto.builder()
+        .id(dto.getId())
+        .latitude(dto.getLatitude())
+        .longitude(dto.getLongitude())
+        .color(dto.getColor())
+        .score(dto.getScore())
+        .build();
+  }
+}

--- a/src/main/java/svsite/matzip/foody/domain/post/api/dto/response/PostResponseDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/dto/response/PostResponseDto.java
@@ -1,0 +1,51 @@
+package svsite.matzip.foody.domain.post.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import svsite.matzip.foody.domain.post.entity.MarkerColor;
+import svsite.matzip.foody.domain.post.entity.Post;
+
+@Builder
+public record PostResponseDto(
+    @Schema(description = "게시글 ID", example = "1")
+    Long id,
+    @Schema(description = "위도 값 (최대 소수점 6자리)", example = "37.566500")
+    BigDecimal latitude,
+    @Schema(description = "경도 값 (최대 소수점 6자리)", example = "126.978000")
+    BigDecimal longitude,
+    @Schema(description = "마커 색상", example = "RED")
+    MarkerColor color,
+    @Schema(description = "주소", example = "서울특별시 종로구")
+    String address,
+    @Schema(description = "게시글 제목", example = "맛집 소개")
+    String title,
+    @Schema(description = "게시글 설명", example = "정말 맛있는 집입니다!")
+    String description,
+    @Schema(description = "방문 날짜", example = "2025-02-08T12:00:00")
+    LocalDateTime date,
+    @Schema(description = "맛집 평점 (0~10)", example = "9")
+    Integer score,
+    @Schema(description = "생성 날짜 및 시간", example = "2025-02-08T12:00:00")
+    LocalDateTime createdAt,
+    @Schema(description = "수정 날짜 및 시간", example = "2025-02-08T13:00:00")
+    LocalDateTime updatedAt
+) {
+
+  public static PostResponseDto from(Post post) {
+    return PostResponseDto.builder()
+        .id(post.getId())
+        .latitude(post.getLatitude())
+        .longitude(post.getLongitude())
+        .color(post.getColor())
+        .address(post.getAddress())
+        .title(post.getTitle())
+        .description(post.getDescription())
+        .date(post.getDate())
+        .score(post.getScore())
+        .createdAt(post.getCreatedAt())
+        .updatedAt(post.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/svsite/matzip/foody/domain/post/entity/Post.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/entity/Post.java
@@ -29,6 +29,7 @@ import svsite.matzip.foody.domain.auth.entity.User;
 import svsite.matzip.foody.domain.favorite.entity.Favorite;
 import svsite.matzip.foody.domain.image.api.Image;
 import svsite.matzip.foody.domain.post.api.dto.request.CreatePostDto;
+import svsite.matzip.foody.domain.post.api.dto.request.UpdatePostDto;
 import svsite.matzip.foody.global.entity.BaseEntity;
 
 @Entity
@@ -86,6 +87,14 @@ public class Post extends BaseEntity {
         .score(postDto.score())
         .user(user)
         .build();
+  }
+
+  public void update(UpdatePostDto postDto) {
+    this.title = postDto.title();
+    this.description = postDto.description();
+    this.color = postDto.color();
+    this.date = postDto.date();
+    this.score = postDto.score();
   }
 
   @Override

--- a/src/main/java/svsite/matzip/foody/domain/post/entity/Post.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/entity/Post.java
@@ -28,6 +28,7 @@ import lombok.NoArgsConstructor;
 import svsite.matzip.foody.domain.auth.entity.User;
 import svsite.matzip.foody.domain.favorite.entity.Favorite;
 import svsite.matzip.foody.domain.image.api.Image;
+import svsite.matzip.foody.domain.post.api.dto.request.CreatePostDto;
 import svsite.matzip.foody.global.entity.BaseEntity;
 
 @Entity
@@ -72,6 +73,20 @@ public class Post extends BaseEntity {
 
   @OneToMany(mappedBy = "post", orphanRemoval = true)
   private List<Favorite> favorites;
+
+  public static Post create(CreatePostDto postDto, User user) {
+    return Post.builder()
+        .latitude(postDto.latitude())
+        .longitude(postDto.longitude())
+        .color(postDto.color())
+        .address(postDto.address())
+        .title(postDto.title())
+        .description(postDto.description())
+        .date(postDto.date())
+        .score(postDto.score())
+        .user(user)
+        .build();
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/svsite/matzip/foody/domain/post/repository/PostRepository.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/repository/PostRepository.java
@@ -2,6 +2,8 @@ package svsite.matzip.foody.domain.post.repository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -27,4 +29,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
       "WHERE p.user = :user " +
       "AND p.id = :id")
   Optional<Post> findByPostIdAndUser(@Param("id") long id, @Param("user") User user);
+
+  @Query("SELECT p " +
+      "FROM Post p " +
+      "LEFT JOIN FETCH p.images i " +
+      "WHERE p.user = :user " +
+      "ORDER BY p.date DESC, i.id ASC")
+  Page<Post> findAllRecentPost(Pageable pageable, @Param("user") User user);
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/repository/PostRepository.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/repository/PostRepository.java
@@ -36,4 +36,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
       "WHERE p.user = :user " +
       "ORDER BY p.date DESC, i.id ASC")
   Page<Post> findAllRecentPost(Pageable pageable, @Param("user") User user);
+
+  @Query("SELECT p FROM Post p " +
+      "WHERE EXTRACT(YEAR FROM p.date) = :year " +
+      "AND EXTRACT(MONTH FROM p.date) = :month " +
+      "AND p.user = :user")
+  List<Post> findPostsByMonth(@Param("year") int year, @Param("month") int month, @Param("user") User user);
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/repository/PostRepository.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/repository/PostRepository.java
@@ -1,0 +1,21 @@
+package svsite.matzip.foody.domain.post.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.post.entity.Post;
+import svsite.matzip.foody.domain.post.repository.dto.PostMarkersQueryDto;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+  @Query("SELECT new svsite.matzip.foody.domain.post.repository.dto.PostMarkersQueryDto(" +
+      "p.id, " +
+      "p.latitude, " +
+      "p.longitude, " +
+      "p.color, " +
+      "p.score) " +
+      "FROM Post p " +
+      "WHERE p.user = :user")
+  List<PostMarkersQueryDto> getAllMarkers(@Param("user") User user);}

--- a/src/main/java/svsite/matzip/foody/domain/post/repository/PostRepository.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/repository/PostRepository.java
@@ -42,4 +42,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
       "AND EXTRACT(MONTH FROM p.date) = :month " +
       "AND p.user = :user")
   List<Post> findPostsByMonth(@Param("year") int year, @Param("month") int month, @Param("user") User user);
+
+  @Query("SELECT p FROM Post p " +
+      "WHERE p.user = :user " +
+      "AND (p.title LIKE %:query% OR p.address LIKE %:query%)")
+  Page<Post> searchByTitleOrAddress(@Param("query") String query, @Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/repository/PostRepository.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package svsite.matzip.foody.domain.post.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +19,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
       "p.score) " +
       "FROM Post p " +
       "WHERE p.user = :user")
-  List<PostMarkersQueryDto> getAllMarkers(@Param("user") User user);}
+  List<PostMarkersQueryDto> getAllMarkers(@Param("user") User user);
+
+  @Query("SELECT p " +
+      "FROM Post p " +
+      "LEFT JOIN FETCH p.images i " +
+      "WHERE p.user = :user " +
+      "AND p.id = :id")
+  Optional<Post> findByPostIdAndUser(@Param("id") long id, @Param("user") User user);
+}

--- a/src/main/java/svsite/matzip/foody/domain/post/repository/dto/PostMarkersQueryDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/repository/dto/PostMarkersQueryDto.java
@@ -1,0 +1,21 @@
+package svsite.matzip.foody.domain.post.repository.dto;
+
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import svsite.matzip.foody.domain.post.entity.MarkerColor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostMarkersQueryDto {
+  private Long id;
+  private BigDecimal latitude;
+  private BigDecimal longitude;
+  private MarkerColor color;
+  private Integer score;
+}

--- a/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
@@ -1,14 +1,19 @@
 package svsite.matzip.foody.domain.post.service;
 
+import static svsite.matzip.foody.global.exception.errorCode.ErrorCodes.POST_NOT_FOUND;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import svsite.matzip.foody.domain.auth.entity.User;
 import svsite.matzip.foody.domain.post.api.dto.request.CreatePostDto;
+import svsite.matzip.foody.domain.post.api.dto.request.UpdatePostDto;
 import svsite.matzip.foody.domain.post.api.dto.response.MarkersResponseDto;
 import svsite.matzip.foody.domain.post.api.dto.response.PostResponseDto;
 import svsite.matzip.foody.domain.post.entity.Post;
 import svsite.matzip.foody.domain.post.repository.PostRepository;
+import svsite.matzip.foody.global.exception.support.CustomException;
 
 @Service
 @RequiredArgsConstructor
@@ -16,16 +21,25 @@ public class PostService {
 
   private final PostRepository postRepository;
 
+  @Transactional(readOnly = true)
   public List<MarkersResponseDto> getAllMarkers(User user) {
     return postRepository.getAllMarkers(user).stream()
         .map(MarkersResponseDto::from)
         .toList();
   }
 
+  @Transactional
   public PostResponseDto createPost(CreatePostDto createPostDto, User user) {
     Post post = Post.create(createPostDto, user);
     postRepository.save(post);
+    return PostResponseDto.from(post);
+  }
 
+  @Transactional
+  public PostResponseDto updatePost(long id, UpdatePostDto updatePostDto, User user) {
+    Post post = postRepository.findByPostIdAndUser(id, user)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    post.update(updatePostDto);
     return PostResponseDto.from(post);
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
@@ -3,6 +3,8 @@ package svsite.matzip.foody.domain.post.service;
 import static svsite.matzip.foody.global.exception.errorCode.ErrorCodes.POST_NOT_FOUND;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -63,5 +65,16 @@ public class PostService {
     Post foundPost = postRepository.findByPostIdAndUser(id, user)
         .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
     return PostResponseDto.from(foundPost);
+  }
+
+  @Transactional(readOnly = true)
+  public Map<Integer, List<PostResponseDto>> getPostsByMonth(int year, int month, User user) {
+    List<Post> posts = postRepository.findPostsByMonth(year, month, user);
+
+    return posts.stream()
+        .collect(Collectors.groupingBy(
+            post -> post.getDate().getDayOfMonth(),
+            Collectors.mapping(PostResponseDto::from, Collectors.toList())
+        ));
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
@@ -57,4 +57,11 @@ public class PostService {
     return postRepository.findAllRecentPost(pageable, user)
         .map(PostResponseDto::from);
   }
+
+  @Transactional(readOnly = true)
+  public PostResponseDto getPostById(long id, User user) {
+    Post foundPost = postRepository.findByPostIdAndUser(id, user)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    return PostResponseDto.from(foundPost);
+  }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
@@ -8,6 +8,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import svsite.matzip.foody.domain.auth.entity.User;
@@ -76,5 +78,11 @@ public class PostService {
             post -> post.getDate().getDayOfMonth(),
             Collectors.mapping(PostResponseDto::from, Collectors.toList())
         ));
+  }
+
+  @Transactional(readOnly = true)
+  public Page<PostResponseDto> searchMyPostsByTitleAndAddress(Pageable pageable, String query, User user) {
+    Page<Post> posts = postRepository.searchByTitleOrAddress(query, user, pageable);
+    return posts.map(PostResponseDto::from);
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
@@ -4,7 +4,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.post.api.dto.request.CreatePostDto;
 import svsite.matzip.foody.domain.post.api.dto.response.MarkersResponseDto;
+import svsite.matzip.foody.domain.post.api.dto.response.PostResponseDto;
+import svsite.matzip.foody.domain.post.entity.Post;
 import svsite.matzip.foody.domain.post.repository.PostRepository;
 
 @Service
@@ -17,5 +20,12 @@ public class PostService {
     return postRepository.getAllMarkers(user).stream()
         .map(MarkersResponseDto::from)
         .toList();
+  }
+
+  public PostResponseDto createPost(CreatePostDto createPostDto, User user) {
+    Post post = Post.create(createPostDto, user);
+    postRepository.save(post);
+
+    return PostResponseDto.from(post);
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
@@ -4,6 +4,8 @@ import static svsite.matzip.foody.global.exception.errorCode.ErrorCodes.POST_NOT
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import svsite.matzip.foody.domain.auth.entity.User;
@@ -41,5 +43,18 @@ public class PostService {
         .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
     post.update(updatePostDto);
     return PostResponseDto.from(post);
+  }
+
+  @Transactional
+  public void deletePost(long id, User user) {
+    Post post = postRepository.findByPostIdAndUser(id, user)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    postRepository.delete(post);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<PostResponseDto> getPosts(PageRequest pageable, User user) {
+    return postRepository.findAllRecentPost(pageable, user)
+        .map(PostResponseDto::from);
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
@@ -1,0 +1,21 @@
+package svsite.matzip.foody.domain.post.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.post.api.dto.response.MarkersResponseDto;
+import svsite.matzip.foody.domain.post.repository.PostRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+  private final PostRepository postRepository;
+
+  public List<MarkersResponseDto> getAllMarkers(User user) {
+    return postRepository.getAllMarkers(user).stream()
+        .map(MarkersResponseDto::from)
+        .toList();
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/config/PageConfig.java
+++ b/src/main/java/svsite/matzip/foody/global/config/PageConfig.java
@@ -1,0 +1,11 @@
+package svsite.matzip.foody.global.config;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+public class PageConfig {
+}

--- a/src/test/java/svsite/matzip/foody/domain/auth/ControllerTestSupport.java
+++ b/src/test/java/svsite/matzip/foody/domain/auth/ControllerTestSupport.java
@@ -7,10 +7,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import svsite.matzip.foody.domain.auth.api.AuthController;
 import svsite.matzip.foody.domain.auth.service.AuthService;
+import svsite.matzip.foody.domain.post.api.PostController;
+import svsite.matzip.foody.domain.post.service.PostService;
 import svsite.matzip.foody.global.auth.AuthenticatedUserResolver;
 
 @WebMvcTest(controllers = {
     AuthController.class,
+    PostController.class
 })
 public abstract class ControllerTestSupport {
   @Autowired
@@ -21,4 +24,6 @@ public abstract class ControllerTestSupport {
   protected AuthService authService;
   @MockBean
   protected AuthenticatedUserResolver authenticatedUserResolver;
+  @MockBean
+  protected PostService postService;
 }

--- a/src/test/java/svsite/matzip/foody/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/auth/service/AuthServiceTest.java
@@ -124,7 +124,8 @@ class AuthServiceTest {
     when(passwordEncoder.matches("wrongPassword", "encodedPassword")).thenReturn(false);
 
     // when & then
-    CustomException exception = assertThrows(CustomException.class, () -> authService.signin(authRequestDto));
+    CustomException exception = assertThrows(CustomException.class,
+        () -> authService.signin(authRequestDto));
     assertEquals(ErrorCodes.USER_WRONG_PASSWORD, exception.getErrorCode());
     verify(userRepository).findByEmail("test@example.com");
     verify(passwordEncoder).matches("wrongPassword", "encodedPassword");
@@ -140,7 +141,8 @@ class AuthServiceTest {
     when(userRepository.findByEmail("notfound@example.com")).thenReturn(Optional.empty());
 
     // when & then
-    CustomException exception = assertThrows(CustomException.class, () -> authService.signin(authRequestDto));
+    CustomException exception = assertThrows(CustomException.class,
+        () -> authService.signin(authRequestDto));
     assertEquals(ErrorCodes.USER_NOT_FOUND, exception.getErrorCode());
     verify(userRepository).findByEmail("notfound@example.com");
     verify(passwordEncoder, never()).matches(anyString(), anyString());

--- a/src/test/java/svsite/matzip/foody/domain/post/api/PostControllerTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/post/api/PostControllerTest.java
@@ -2,12 +2,17 @@ package svsite.matzip.foody.domain.post.api;
 
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +21,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import svsite.matzip.foody.domain.auth.ControllerTestSupport;
 import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.post.api.dto.request.CreatePostDto;
 import svsite.matzip.foody.domain.post.api.dto.response.MarkersResponseDto;
+import svsite.matzip.foody.domain.post.api.dto.response.PostResponseDto;
 import svsite.matzip.foody.domain.post.entity.MarkerColor;
 
 class PostControllerTest extends ControllerTestSupport {
@@ -25,15 +32,10 @@ class PostControllerTest extends ControllerTestSupport {
   @Test
   void getAllMarkers() throws Exception {
     // given
-    User mockUser = User.builder()
-        .email("test@example.com")
-        .hashedRefreshToken("hashedRefreshToken")
-        .build();
+    User mockUser = setupAuthenticatedUser();
 
     List<MarkersResponseDto> markersResponseDtos = getMockedMarkers();
 
-    when(authenticatedUserResolver.supportsParameter(any())).thenReturn(true);
-    when(authenticatedUserResolver.resolveArgument(any(), any(), any(), any())).thenReturn(mockUser);
     when(postService.getAllMarkers(any(User.class))).thenReturn(markersResponseDtos);
 
     // when & then
@@ -49,6 +51,58 @@ class PostControllerTest extends ControllerTestSupport {
         .andExpect(jsonPath("$[0].score").value(10))
         .andExpect(jsonPath("$[1].color").value("BLUE"))
         .andExpect(jsonPath("$[2].color").value("GREEN"));
+  }
+
+  @Test
+  @DisplayName("맛집 글을 성공적으로 등록한다")
+  void createPost() throws Exception {
+    // given
+    User mockUser = setupAuthenticatedUser();
+
+    CreatePostDto createPostDto = new CreatePostDto(
+        BigDecimal.valueOf(37.5665),
+        BigDecimal.valueOf(126.9780),
+        MarkerColor.RED,
+        "서울특별시 종로구",
+        "맛집 소개",
+        "정말 맛있는 집입니다!",
+        LocalDateTime.of(2025, 2, 8, 12, 0, 0),
+        9,
+        List.of("https://example.com/image1.jpg", "https://example.com/image2.jpg")
+    );
+
+    PostResponseDto responseDto = PostResponseDto.builder()
+        .id(1L)
+        .latitude(BigDecimal.valueOf(37.5665))
+        .longitude(BigDecimal.valueOf(126.9780))
+        .color(MarkerColor.RED)
+        .address("서울특별시 종로구")
+        .title("맛집 소개")
+        .description("정말 맛있는 집입니다!")
+        .date(LocalDateTime.of(2025, 2, 8, 12, 0, 0))
+        .score(9)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    when(postService.createPost(any(CreatePostDto.class), any(User.class))).thenReturn(responseDto);
+
+    // when & then
+    mockMvc.perform(post("/posts")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer validToken")
+            .content(objectMapper.writeValueAsString(createPostDto))  // JSON 변환 후 전송
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.latitude").value(37.5665))
+        .andExpect(jsonPath("$.longitude").value(126.9780))
+        .andExpect(jsonPath("$.color").value("RED"))
+        .andExpect(jsonPath("$.address").value("서울특별시 종로구"))
+        .andExpect(jsonPath("$.title").value("맛집 소개"))
+        .andExpect(jsonPath("$.description").value("정말 맛있는 집입니다!"))
+        .andExpect(jsonPath("$.score").value(9));
+
+    verify(postService).createPost(any(CreatePostDto.class), eq(mockUser));
   }
 
   private MarkersResponseDto createMarker(Long id, double latitude, double longitude, MarkerColor color, int score) {
@@ -67,5 +121,17 @@ class PostControllerTest extends ControllerTestSupport {
         createMarker(2L, 35.1796, 129.0756, MarkerColor.BLUE, 8),
         createMarker(3L, 33.4996, 126.5312, MarkerColor.GREEN, 9)
     );
+  }
+
+  private User setupAuthenticatedUser() throws Exception {
+    User mockUser = User.builder()
+        .email("test@example.com")
+        .hashedRefreshToken("hashedRefreshToken")
+        .build();
+
+    when(authenticatedUserResolver.supportsParameter(any())).thenReturn(true);
+    when(authenticatedUserResolver.resolveArgument(any(), any(), any(), any())).thenReturn(mockUser);
+
+    return mockUser;
   }
 }

--- a/src/test/java/svsite/matzip/foody/domain/post/api/PostControllerTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/post/api/PostControllerTest.java
@@ -1,0 +1,71 @@
+package svsite.matzip.foody.domain.post.api;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import svsite.matzip.foody.domain.auth.ControllerTestSupport;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.post.api.dto.response.MarkersResponseDto;
+import svsite.matzip.foody.domain.post.entity.MarkerColor;
+
+class PostControllerTest extends ControllerTestSupport {
+
+  @DisplayName("사용자가 등록한 모든 맛집 좌표(마커)를 반환한다")
+  @Test
+  void getAllMarkers() throws Exception {
+    // given
+    User mockUser = User.builder()
+        .email("test@example.com")
+        .hashedRefreshToken("hashedRefreshToken")
+        .build();
+
+    List<MarkersResponseDto> markersResponseDtos = getMockedMarkers();
+
+    when(authenticatedUserResolver.supportsParameter(any())).thenReturn(true);
+    when(authenticatedUserResolver.resolveArgument(any(), any(), any(), any())).thenReturn(mockUser);
+    when(postService.getAllMarkers(any(User.class))).thenReturn(markersResponseDtos);
+
+    // when & then
+    mockMvc.perform(get("/markers/my")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer validRefreshToken")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(3))  // 응답 크기 확인
+        .andExpect(jsonPath("$[0].id").value(1))
+        .andExpect(jsonPath("$[0].latitude").value(37.5665))
+        .andExpect(jsonPath("$[0].longitude").value(126.9780))
+        .andExpect(jsonPath("$[0].color").value("RED"))
+        .andExpect(jsonPath("$[0].score").value(10))
+        .andExpect(jsonPath("$[1].color").value("BLUE"))
+        .andExpect(jsonPath("$[2].color").value("GREEN"));
+  }
+
+  private MarkersResponseDto createMarker(Long id, double latitude, double longitude, MarkerColor color, int score) {
+    return MarkersResponseDto.builder()
+        .id(id)
+        .latitude(BigDecimal.valueOf(latitude))
+        .longitude(BigDecimal.valueOf(longitude))
+        .color(color)
+        .score(score)
+        .build();
+  }
+
+  private List<MarkersResponseDto> getMockedMarkers() {
+    return Arrays.asList(
+        createMarker(1L, 37.5665, 126.9780, MarkerColor.RED, 10),
+        createMarker(2L, 35.1796, 129.0756, MarkerColor.BLUE, 8),
+        createMarker(3L, 33.4996, 126.5312, MarkerColor.GREEN, 9)
+    );
+  }
+}

--- a/src/test/java/svsite/matzip/foody/domain/post/service/PostServiceTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/post/service/PostServiceTest.java
@@ -1,0 +1,95 @@
+package svsite.matzip.foody.domain.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.post.api.dto.response.MarkersResponseDto;
+import svsite.matzip.foody.domain.post.entity.MarkerColor;
+import svsite.matzip.foody.domain.post.repository.PostRepository;
+import svsite.matzip.foody.domain.post.repository.dto.PostMarkersQueryDto;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+  @InjectMocks
+  private PostService postService;
+
+  @Mock
+  private PostRepository postRepository;
+
+  @Test
+  @DisplayName("등록된 맛집 마커가 없을 경우 빈 리스트를 반환한다")
+  void getAllMarkers_emptyList() {
+    // given
+    User mockUser = User.builder().email("empty@example.com").build();
+
+    when(postRepository.getAllMarkers(mockUser)).thenReturn(Collections.emptyList());
+
+    // when
+    List<MarkersResponseDto> allMarkers = postService.getAllMarkers(mockUser);
+
+    // then
+    assertNotNull(allMarkers, "결과 리스트는 null이 아니어야 합니다.");
+    assertTrue(allMarkers.isEmpty(), "결과 리스트는 빈 리스트여야 합니다.");
+  }
+
+  private BigDecimal roundCoordinate(double value) {
+    return BigDecimal.valueOf(value).setScale(6, RoundingMode.HALF_UP);
+  }
+
+  @Test
+  @DisplayName("등록된 맛집 마커 목록을 올바르게 조회한다")
+  void getAllMarkers() {
+    // given
+    User mockUser = User.builder().email("test@example.com").build();
+    List<PostMarkersQueryDto> markersResponseDtos = getMockedMarkers();
+
+    // Mock 설정
+    when(postRepository.getAllMarkers(any(User.class))).thenReturn(markersResponseDtos);
+
+    // when
+    List<MarkersResponseDto> allMarkers = postService.getAllMarkers(mockUser);
+
+    // then
+    assertThat(allMarkers).hasSize(3)
+        .extracting("id", "latitude", "longitude", "color", "score")
+        .containsExactlyInAnyOrder(
+            tuple(1L, roundCoordinate(37.5665), roundCoordinate(126.9780), MarkerColor.RED, 10),
+            tuple(2L, roundCoordinate(35.1796), roundCoordinate(129.0756), MarkerColor.BLUE, 8),
+            tuple(3L, roundCoordinate(33.4996), roundCoordinate(126.5312), MarkerColor.GREEN, 9)
+        );
+  }
+
+  private PostMarkersQueryDto createMarker(Long id, double lat, double lon, MarkerColor color, int score) {
+    return PostMarkersQueryDto.builder()
+        .id(id)
+        .latitude(BigDecimal.valueOf(lat).setScale(6, RoundingMode.HALF_UP))
+        .longitude(BigDecimal.valueOf(lon).setScale(6, RoundingMode.HALF_UP))
+        .color(color)
+        .score(score)
+        .build();
+  }
+
+  private List<PostMarkersQueryDto> getMockedMarkers() {
+    return Arrays.asList(
+        createMarker(1L, 37.5665, 126.9780, MarkerColor.RED, 10),
+        createMarker(2L, 35.1796, 129.0756, MarkerColor.BLUE, 8),
+        createMarker(3L, 33.4996, 126.5312, MarkerColor.GREEN, 9)
+    );
+  }
+}

--- a/src/test/java/svsite/matzip/foody/domain/post/service/PostServiceTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/post/service/PostServiceTest.java
@@ -250,6 +250,57 @@ class PostServiceTest {
     verify(postRepository).findAllRecentPost(pageable, mockUser);
   }
 
+  @Test
+  @DisplayName("게시글 단건을 성공적으로 조회한다")
+  void getPostById_success() {
+    // given
+    User mockUser = User.builder().email("test@example.com").build();
+
+    Post existingPost = Post.builder()
+        .id(1L)
+        .latitude(BigDecimal.valueOf(37.5665))
+        .longitude(BigDecimal.valueOf(126.9780))
+        .color(MarkerColor.RED)
+        .address("서울특별시 종로구")
+        .title("맛집 소개")
+        .description("정말 맛있는 집입니다!")
+        .date(LocalDateTime.of(2025, 2, 8, 12, 0, 0))
+        .score(9)
+        .user(mockUser)
+        .build();
+
+    when(postRepository.findByPostIdAndUser(1L, mockUser)).thenReturn(Optional.of(existingPost));
+
+    // when
+    PostResponseDto responseDto = postService.getPostById(1L, mockUser);
+
+    // then
+    assertNotNull(responseDto, "응답은 null이 아니어야 합니다.");
+    assertEquals(1L, responseDto.id(), "ID가 예상 값과 일치해야 합니다.");
+    assertEquals(existingPost.getTitle(), responseDto.title(), "제목이 예상 값과 일치해야 합니다.");
+    assertEquals(existingPost.getLatitude(), responseDto.latitude(), "위도가 예상 값과 일치해야 합니다.");
+    assertEquals(existingPost.getLongitude(), responseDto.longitude(), "경도가 예상 값과 일치해야 합니다.");
+    assertEquals(existingPost.getColor(), responseDto.color(), "마커 색상이 예상 값과 일치해야 합니다.");
+
+    verify(postRepository).findByPostIdAndUser(1L, mockUser);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 게시글 조회 시 예외가 발생한다")
+  void getPostById_postNotFound_throwsException() {
+    // given
+    User mockUser = User.builder().email("test@example.com").build();
+
+    when(postRepository.findByPostIdAndUser(1L, mockUser)).thenReturn(Optional.empty());
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () -> postService.getPostById(1L, mockUser));
+
+    assertEquals("해당 게시물을 찾을 수 없습니다.", exception.getMessage(), "예외 메시지가 예상과 일치해야 합니다.");
+
+    verify(postRepository).findByPostIdAndUser(1L, mockUser);
+  }
+
   private Post createMockPost(Long id, String title, String description) {
     return Post.builder()
         .id(id)

--- a/src/test/java/svsite/matzip/foody/domain/post/service/PostServiceTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/post/service/PostServiceTest.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import svsite.matzip.foody.domain.auth.entity.User;
 import svsite.matzip.foody.domain.post.api.dto.request.CreatePostDto;
+import svsite.matzip.foody.domain.post.api.dto.request.UpdatePostDto;
 import svsite.matzip.foody.domain.post.api.dto.response.MarkersResponseDto;
 import svsite.matzip.foody.domain.post.api.dto.response.PostResponseDto;
 import svsite.matzip.foody.domain.post.entity.MarkerColor;
@@ -101,6 +103,52 @@ class PostServiceTest {
     assertEquals(createPostDto.title(), responseDto.title(), "제목이 예상 값과 일치해야 합니다.");
 
     verify(postRepository).save(any(Post.class));
+  }
+
+  @Test
+  @DisplayName("맛집 글을 성공적으로 수정한다")
+  void updatePost() {
+    // given
+    User mockUser = User.builder()
+        .email("test@example.com")
+        .nickname("테스터")
+        .build();
+
+    Post existingPost = Post.builder()
+        .id(1L)
+        .latitude(BigDecimal.valueOf(37.5665))
+        .longitude(BigDecimal.valueOf(126.9780))
+        .color(MarkerColor.RED)
+        .address("서울특별시 종로구")
+        .title("기존 맛집 소개")
+        .description("기존 설명")
+        .date(LocalDateTime.of(2025, 2, 7, 12, 0))
+        .score(8)
+        .user(mockUser)
+        .build();
+
+    UpdatePostDto updatePostDto = new UpdatePostDto(
+        MarkerColor.BLUE,
+        "수정된 맛집 소개",
+        "수정된 설명",
+        LocalDateTime.of(2025, 2, 8, 15, 30, 0),
+        9
+    );
+
+    when(postRepository.findByPostIdAndUser(1L, mockUser)).thenReturn(Optional.of(existingPost));
+
+    // when
+    PostResponseDto responseDto = postService.updatePost(1L, updatePostDto, mockUser);
+
+    // then
+    assertNotNull(responseDto, "응답은 null이 아니어야 합니다.");
+    assertEquals(1L, responseDto.id(), "ID가 예상 값과 일치해야 합니다.");
+    assertEquals(updatePostDto.title(), responseDto.title(), "제목이 예상 값과 일치해야 합니다.");
+    assertEquals(updatePostDto.color(), responseDto.color(), "마커 색상이 예상 값과 일치해야 합니다.");
+    assertEquals(updatePostDto.description(), responseDto.description(), "설명이 예상 값과 일치해야 합니다.");
+    assertEquals(updatePostDto.date(), responseDto.date(), "날짜가 예상 값과 일치해야 합니다.");
+
+    verify(postRepository).findByPostIdAndUser(1L, mockUser);
   }
 
   private CreatePostDto getSampleCreatePostDto() {


### PR DESCRIPTION
### **1. PR 개요**  
`PostController`, `PostService`, `PostRepository`를 구현하고 API 명세에 맞는 기능들을 추가하였습니다.

---

### **2. 주요 변경 사항 및 설명**

##### **1) 게시글 관리 기능 구현**  
- 맛집 게시글에 대한 CRUD 기능을 제공하는 `PostController`, `PostService`, `PostRepository`를 구현했습니다.
- 기능별로 API를 정의하고 Swagger(OpenAPI) 명세를 추가하여 문서화했습니다.

##### **2) 게시글 마커 조회**  
- 사용자가 등록한 게시글들의 좌표(마커)를 반환하는 API를 구현하였습니다.
- API 경로: `/markers/my`  
```java
@GetMapping("/markers/my")
public ResponseEntity<List<MarkersResponseDto>> getAllMarkers(@AuthenticatedUser User user)
```

##### **3) 게시글 등록**  
- 맛집 게시글 등록 기능을 구현했습니다.
- 입력 데이터에 대한 유효성 검사를 위해 DTO에 제약 조건을 추가했습니다.  
- API 경로: `/posts`  
```java
@PostMapping("/posts")
public ResponseEntity<PostResponseDto> createPost(@RequestBody @Valid CreatePostDto createPostDto, @AuthenticatedUser User user)
```

##### **4) 게시글 수정 및 삭제 기능**  
- 사용자가 본인의 게시글을 수정하거나 삭제할 수 있도록 API를 구현했습니다.
- API 경로:  
  - 수정: `/posts/{id}` (`PATCH`)
  - 삭제: `/posts/{id}` (`DELETE`)
```java
@PatchMapping("/posts/{id}")
public ResponseEntity<PostResponseDto> updatePost(@PathVariable("id") long id, @RequestBody @Valid UpdatePostDto updatePostDto, @AuthenticatedUser User user)

@DeleteMapping("/posts/{id}")
public ResponseEntity<Void> deletePost(@PathVariable("id") long id, @AuthenticatedUser User user)
```

##### **5) 게시글 목록 및 검색 기능 구현**  
- 사용자가 등록한 게시글들을 페이지 단위로 조회하는 API를 구현했습니다.
- 연도와 월별로 게시글을 그룹화하여 조회할 수 있는 기능도 제공됩니다.
- API 경로:  
  - 목록 조회: `/posts/my`
  - 검색: `/posts/my/search`
  - 월별 조회: `/posts`  
```java
@GetMapping("/posts/my")
public ResponseEntity<Page<PostResponseDto>> getPosts(@RequestParam(defaultValue = "0") @PositiveOrZero int page, @RequestParam(defaultValue = "10") @PositiveOrZero int size, @AuthenticatedUser User user)

@GetMapping("/posts")
public Map<Integer, List<PostResponseDto>> getPostsByMonth(@RequestParam("year") int year, @RequestParam("month") int month, @AuthenticatedUser User user)

@GetMapping("/posts/my/search")
public Page<PostResponseDto> searchMyPostsByTitleAndAddress(@RequestParam("query") String query, @RequestParam(defaultValue = "0") @PositiveOrZero int page, @RequestParam(defaultValue = "10") @Positive int size, @AuthenticatedUser User user)
```

---

### **3. 설계 의도 및 고려 사항**  
- 게시글의 CRUD 기능에서 발생할 수 있는 다양한 예외 상황을 고려하여 처리했습니다.
- Swagger 명세를 통해 API 문서화 및 개발자 간 원활한 협업을 지원했습니다.

---

### **4. 테스트 및 검증**  
- 각 기능에 대한 단위 테스트를 수행하여 정상 동작을 확인했습니다.
  - **게시글 등록** 테스트
  - **게시글 조회 및 검색** 테스트
  - **게시글 수정 및 삭제** 테스트
  - **예외 처리** 테스트

---

### **5. 기타 참고 사항**  
- API 명세는 Swagger UI에서 확인할 수 있습니다.

---

**This closes #15** 
