### PR TITLE
#17 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/svsite/matzip/foody/domain/image/api/ImageController.java
+++ b/src/main/java/svsite/matzip/foody/domain/image/api/ImageController.java
@@ -1,0 +1,68 @@
+package svsite.matzip.foody.domain.image.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.global.auth.AuthenticatedUser;
+import svsite.matzip.foody.global.util.file.service.FileUploadService;
+
+@RestController
+@RequestMapping("/images")
+@RequiredArgsConstructor
+@Tag(name = "Image API", description = "이미지 업로드 및 관리 API")  // 태그 이름 추가
+public class ImageController {
+
+  private final FileUploadService fileUploadService;
+
+  @Operation(
+      summary = "이미지 업로드",
+      description = "사용자가 여러 이미지를 업로드할 수 있는 API입니다.",
+      responses = {
+          @ApiResponse(
+              responseCode = "200",
+              description = "업로드 성공",
+              content = @Content(
+                  mediaType = "application/json",
+                  schema = @Schema(implementation = List.class, description = "업로드된 파일 URL 목록")
+              )
+          ),
+          @ApiResponse(
+              responseCode = "400",
+              description = "업로드 실패 (잘못된 요청)",
+              content = @Content(mediaType = "application/json")
+          ),
+          @ApiResponse(
+              responseCode = "401",
+              description = "인증 실패",
+              content = @Content(mediaType = "application/json")
+          )
+      },
+      security = @SecurityRequirement(name = "bearerAuth")
+  )
+  @PostMapping
+  public ResponseEntity<List<String>> uploadImages(
+      @AuthenticatedUser User user,
+      @Parameter(
+          description = "업로드할 이미지 파일 목록",
+          required = true,
+          content = @Content(mediaType = "multipart/form-data")
+      )
+      @RequestParam("files") List<MultipartFile> files
+  ) {
+    List<String> fileUrls = fileUploadService.uploadFiles(files);
+    return ResponseEntity.ok(fileUrls);
+  }
+}

--- a/src/main/java/svsite/matzip/foody/domain/image/entity/Image.java
+++ b/src/main/java/svsite/matzip/foody/domain/image/entity/Image.java
@@ -1,4 +1,4 @@
-package svsite.matzip.foody.domain.image.api;
+package svsite.matzip.foody.domain.image.entity;
 
 import static jakarta.persistence.FetchType.LAZY;
 
@@ -33,6 +33,23 @@ public class Image extends BaseEntity {
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name="post_id")
   Post post;
+
+  public void associateWithPost(Post post) {
+    if (this.post != null) {
+      this.post.getImages().remove(this);
+    }
+    this.post = post;
+    if (post != null && !post.getImages().contains(this)) {
+      post.getImages().add(this);
+    }
+  }
+
+  public void dissociateFromPost() {
+    if (this.post != null) {
+      this.post.getImages().remove(this);
+      this.post = null;
+    }
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/svsite/matzip/foody/domain/image/repository/ImageRepository.java
+++ b/src/main/java/svsite/matzip/foody/domain/image/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package svsite.matzip.foody.domain.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import svsite.matzip.foody.domain.image.entity.Image;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/svsite/matzip/foody/domain/post/api/dto/request/UpdatePostDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/dto/request/UpdatePostDto.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.List;
 import svsite.matzip.foody.domain.post.entity.MarkerColor;
 
 @Schema(description = "맛집 글 수정 요청 DTO")
@@ -34,5 +35,8 @@ public record UpdatePostDto(
     @Schema(description = "맛집 점수 (0 ~ 10)", example = "9")
     @Min(value = 0, message = "점수는 최소 0이어야 합니다.")
     @Max(value = 10, message = "점수는 최대 10이어야 합니다.")
-    Integer score
+    Integer score,
+
+    @Schema(description = "게시글에 첨부된 이미지 uri")
+    List<String> imageUris
 ) {}

--- a/src/main/java/svsite/matzip/foody/domain/post/api/dto/response/ImageResponseDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/dto/response/ImageResponseDto.java
@@ -1,0 +1,20 @@
+package svsite.matzip.foody.domain.post.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record ImageResponseDto(
+    @Schema(description = "이미지 ID", example = "10")
+    Long id,
+    @Schema(description = "이미지 URL", example = "https://example.com/images/1.jpg")
+    String uri,
+    @Schema(description = "이미지 생성 날짜 및 시간", example = "2025-02-08T12:00:00")
+    LocalDateTime createdAt,
+    @Schema(description = "이미지 수정 날짜 및 시간", example = "2025-02-08T13:00:00")
+    LocalDateTime updatedAt,
+    @Schema(description = "이미지 삭제 날짜 및 시간", example = "2025-02-09T12:00:00")
+    LocalDateTime deletedAt
+) {
+}

--- a/src/main/java/svsite/matzip/foody/domain/post/api/dto/response/PostResponseDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/dto/response/PostResponseDto.java
@@ -3,6 +3,9 @@ package svsite.matzip.foody.domain.post.api.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 import lombok.Builder;
 import svsite.matzip.foody.domain.post.entity.MarkerColor;
 import svsite.matzip.foody.domain.post.entity.Post;
@@ -30,7 +33,9 @@ public record PostResponseDto(
     @Schema(description = "생성 날짜 및 시간", example = "2025-02-08T12:00:00")
     LocalDateTime createdAt,
     @Schema(description = "수정 날짜 및 시간", example = "2025-02-08T13:00:00")
-    LocalDateTime updatedAt
+    LocalDateTime updatedAt,
+    @Schema(description = "게시글에 첨부된 이미지 목록")
+    List<ImageResponseDto> images
 ) {
 
   public static PostResponseDto from(Post post) {
@@ -44,6 +49,17 @@ public record PostResponseDto(
         .description(post.getDescription())
         .date(post.getDate())
         .score(post.getScore())
+        .images(post.getImages().stream()
+            .sorted(Comparator.comparingLong(
+                image -> Optional.ofNullable(image.getId()).orElse(0L)))
+            .map(image -> ImageResponseDto.builder()
+                .id(image.getId())
+                .uri(image.getUri())
+                .createdAt(image.getCreatedAt())
+                .updatedAt(image.getUpdatedAt())
+                .deletedAt(image.getDeletedAt())
+                .build())
+            .toList())
         .createdAt(post.getCreatedAt())
         .updatedAt(post.getUpdatedAt())
         .build();

--- a/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
@@ -9,10 +9,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.image.entity.Image;
 import svsite.matzip.foody.domain.post.api.dto.request.CreatePostDto;
 import svsite.matzip.foody.domain.post.api.dto.request.UpdatePostDto;
 import svsite.matzip.foody.domain.post.api.dto.response.MarkersResponseDto;
@@ -45,7 +45,12 @@ public class PostService {
   public PostResponseDto updatePost(long id, UpdatePostDto updatePostDto, User user) {
     Post post = postRepository.findByPostIdAndUser(id, user)
         .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
     post.update(updatePostDto);
+    post.updateImages(updatePostDto.imageUris().stream()
+        .map(uri -> Image.builder().uri(uri).build())
+        .toList());
+
     return PostResponseDto.from(post);
   }
 
@@ -81,7 +86,8 @@ public class PostService {
   }
 
   @Transactional(readOnly = true)
-  public Page<PostResponseDto> searchMyPostsByTitleAndAddress(Pageable pageable, String query, User user) {
+  public Page<PostResponseDto> searchMyPostsByTitleAndAddress(Pageable pageable, String query,
+      User user) {
     Page<Post> posts = postRepository.searchByTitleOrAddress(query, user, pageable);
     return posts.map(PostResponseDto::from);
   }

--- a/src/main/java/svsite/matzip/foody/global/config/ImageConfig.java
+++ b/src/main/java/svsite/matzip/foody/global/config/ImageConfig.java
@@ -1,0 +1,15 @@
+package svsite.matzip.foody.global.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class ImageConfig {
+  @Value("${image.max-count}")
+  private int maxImageCount;
+
+  @Value("${image.max-size}")
+  private long maxImageSize;
+}

--- a/src/main/java/svsite/matzip/foody/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/svsite/matzip/foody/global/exception/GlobalExceptionHandler.java
@@ -15,6 +15,8 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import svsite.matzip.foody.global.exception.response.ApiResponseError;
 import svsite.matzip.foody.global.exception.support.CustomException;
+import svsite.matzip.foody.global.util.file.exception.FileStorageException;
+import svsite.matzip.foody.global.util.file.exception.FileUploadException;
 
 @Slf4j
 @RestControllerAdvice
@@ -87,6 +89,26 @@ public final class GlobalExceptionHandler {
     String message = String.format("파라미터 '%s'의 값 '%s'가 올바르지 않습니다.", exception.getName(),
         exception.getValue());
     return handleException("TYPE_MISMATCH", HttpStatus.BAD_REQUEST, message, request, false);
+  }
+
+  // 파일 업로드 커스텀 예외 처리
+  @ExceptionHandler(FileUploadException.class)
+  public ResponseEntity<ApiResponseError> handleFileUploadException(
+      FileUploadException exception, HttpServletRequest request) {
+
+    return handleException(
+        "FILE_UPLOAD_ERROR", exception.getStatus(), exception.getMessage(), request, true
+    );
+  }
+
+  // 파일 저장 예외 처리 (I/O 오류 등)
+  @ExceptionHandler(FileStorageException.class)
+  public ResponseEntity<ApiResponseError> handleFileStorageException(
+      FileStorageException exception, HttpServletRequest request) {
+
+    return handleException(
+        "FILE_STORAGE_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, "파일 저장 중 오류가 발생했습니다.", request, true
+    );
   }
 
   // 공통 예외 처리 메서드

--- a/src/main/java/svsite/matzip/foody/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/svsite/matzip/foody/global/exception/GlobalExceptionHandler.java
@@ -97,7 +97,7 @@ public final class GlobalExceptionHandler {
       FileUploadException exception, HttpServletRequest request) {
 
     return handleException(
-        "FILE_UPLOAD_ERROR", exception.getStatus(), exception.getMessage(), request, true
+        "FILE_UPLOAD_ERROR", exception.getErrorCode().defaultHttpStatus(), exception.getMessage(), request, true
     );
   }
 

--- a/src/main/java/svsite/matzip/foody/global/util/file/exception/FileStorageException.java
+++ b/src/main/java/svsite/matzip/foody/global/util/file/exception/FileStorageException.java
@@ -1,0 +1,7 @@
+package svsite.matzip.foody.global.util.file.exception;
+
+public class FileStorageException extends RuntimeException {
+  public FileStorageException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/util/file/exception/FileStorageException.java
+++ b/src/main/java/svsite/matzip/foody/global/util/file/exception/FileStorageException.java
@@ -1,7 +1,32 @@
 package svsite.matzip.foody.global.util.file.exception;
 
-public class FileStorageException extends RuntimeException {
+import svsite.matzip.foody.global.exception.support.CustomException;
+import svsite.matzip.foody.global.exception.support.ErrorCode;
+
+public class FileStorageException extends CustomException {
+
+  @Override
+  public ErrorCode getErrorCode() {
+    return super.getErrorCode();
+  }
+
+  public FileStorageException() {
+    super();
+  }
+
+  public FileStorageException(String message) {
+    super(message);
+  }
+
   public FileStorageException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  public FileStorageException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public FileStorageException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
   }
 }

--- a/src/main/java/svsite/matzip/foody/global/util/file/exception/FileUploadException.java
+++ b/src/main/java/svsite/matzip/foody/global/util/file/exception/FileUploadException.java
@@ -1,0 +1,16 @@
+package svsite.matzip.foody.global.util.file.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class FileUploadException extends RuntimeException {
+  private final HttpStatus status;
+
+  public FileUploadException(String message, HttpStatus status) {
+    super(message);
+    this.status = status;
+  }
+
+  public HttpStatus getStatus() {
+    return status;
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/util/file/exception/FileUploadException.java
+++ b/src/main/java/svsite/matzip/foody/global/util/file/exception/FileUploadException.java
@@ -1,16 +1,27 @@
 package svsite.matzip.foody.global.util.file.exception;
 
-import org.springframework.http.HttpStatus;
+import svsite.matzip.foody.global.exception.support.CustomException;
+import svsite.matzip.foody.global.exception.support.ErrorCode;
 
-public class FileUploadException extends RuntimeException {
-  private final HttpStatus status;
+public class FileUploadException extends CustomException {
 
-  public FileUploadException(String message, HttpStatus status) {
-    super(message);
-    this.status = status;
+  public FileUploadException() {
   }
 
-  public HttpStatus getStatus() {
-    return status;
+  public FileUploadException(String message) {
+    super(message);
+  }
+
+  public FileUploadException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public FileUploadException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public FileUploadException(ErrorCode errorCode,
+      Throwable cause) {
+    super(errorCode, cause);
   }
 }

--- a/src/main/java/svsite/matzip/foody/global/util/file/service/FileStorageService.java
+++ b/src/main/java/svsite/matzip/foody/global/util/file/service/FileStorageService.java
@@ -1,0 +1,9 @@
+package svsite.matzip.foody.global.util.file.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileStorageService {
+  String saveFile(MultipartFile file);
+  void deleteFile(String fileName);
+  String getFileUrl(String fileName);
+}

--- a/src/main/java/svsite/matzip/foody/global/util/file/service/FileUploadService.java
+++ b/src/main/java/svsite/matzip/foody/global/util/file/service/FileUploadService.java
@@ -1,0 +1,51 @@
+package svsite.matzip.foody.global.util.file.service;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
+import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import svsite.matzip.foody.global.config.ImageConfig;
+import svsite.matzip.foody.global.util.file.exception.FileUploadException;
+
+@Service
+@RequiredArgsConstructor
+public class FileUploadService {
+
+  private final FileStorageService fileStorageService;
+  private final ImageConfig imageConfig;
+
+  public List<String> uploadFiles(List<MultipartFile> files) {
+    validateFileCount(files.size());
+
+    return files.stream()
+        .map(this::validateAndSaveFile)
+        .collect(Collectors.toList());
+  }
+
+  private void validateFileCount(int size) {
+    if (size > imageConfig.getMaxImageCount()) {
+      throw new FileUploadException(
+          "최대 " + imageConfig.getMaxImageCount() + "개의 파일만 업로드할 수 있습니다.", BAD_REQUEST
+      );
+    }
+  }
+
+  private String validateAndSaveFile(MultipartFile file) {
+    if (!Objects.requireNonNull(file.getContentType()).startsWith("image/")) {
+      throw new FileUploadException("허용되지 않은 파일 형식입니다.", UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    if (file.getSize() > imageConfig.getMaxImageSize()) {
+      throw new FileUploadException("파일 크기가 초과되었습니다. 최대 " + imageConfig.getMaxImageSize() + " bytes까지 허용됩니다.", PAYLOAD_TOO_LARGE);
+    }
+
+    String fileName = fileStorageService.saveFile(file);
+    return fileStorageService.getFileUrl(fileName);
+  }
+}

--- a/src/main/java/svsite/matzip/foody/global/util/file/service/FileUploadService.java
+++ b/src/main/java/svsite/matzip/foody/global/util/file/service/FileUploadService.java
@@ -1,9 +1,5 @@
 package svsite.matzip.foody.global.util.file.service;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
-import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -31,18 +27,17 @@ public class FileUploadService {
   private void validateFileCount(int size) {
     if (size > imageConfig.getMaxImageCount()) {
       throw new FileUploadException(
-          "최대 " + imageConfig.getMaxImageCount() + "개의 파일만 업로드할 수 있습니다.", BAD_REQUEST
-      );
+          "최대 " + imageConfig.getMaxImageCount() + "개의 파일만 업로드할 수 있습니다.");
     }
   }
 
   private String validateAndSaveFile(MultipartFile file) {
     if (!Objects.requireNonNull(file.getContentType()).startsWith("image/")) {
-      throw new FileUploadException("허용되지 않은 파일 형식입니다.", UNSUPPORTED_MEDIA_TYPE);
+      throw new FileUploadException("허용되지 않은 파일 형식입니다.");
     }
 
     if (file.getSize() > imageConfig.getMaxImageSize()) {
-      throw new FileUploadException("파일 크기가 초과되었습니다. 최대 " + imageConfig.getMaxImageSize() + " bytes까지 허용됩니다.", PAYLOAD_TOO_LARGE);
+      throw new FileUploadException("파일 크기가 초과되었습니다. 최대 " + imageConfig.getMaxImageSize() + " bytes까지 허용됩니다.");
     }
 
     String fileName = fileStorageService.saveFile(file);

--- a/src/main/java/svsite/matzip/foody/global/util/file/service/LocalFileStorageService.java
+++ b/src/main/java/svsite/matzip/foody/global/util/file/service/LocalFileStorageService.java
@@ -1,0 +1,59 @@
+package svsite.matzip.foody.global.util.file.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import svsite.matzip.foody.global.util.file.exception.FileStorageException;
+
+@Slf4j
+@Component
+@Profile("dev")
+public class LocalFileStorageService implements FileStorageService {
+
+  @Value("${file.upload-dir}")
+  private String uploadDir;
+
+  @Override
+  public String saveFile(MultipartFile file) {
+    try {
+      String fileName = UUID.randomUUID() + getFileExtension(
+          Objects.requireNonNull(file.getOriginalFilename()));
+      File destination = new File(uploadDir, fileName);
+      file.transferTo(destination);
+      return fileName;
+    } catch (IOException e) {
+      throw new FileStorageException("파일 저장 중 오류 발생", e);
+    }
+  }
+
+  @Override
+  public void deleteFile(String fileName) {
+    Path path = Paths.get(uploadDir, fileName);
+    try {
+      Files.delete(path);
+    } catch (NoSuchFileException e) {
+      log.warn("삭제하려는 파일 '{}'이 존재하지 않습니다.", fileName);
+    } catch (IOException e) {
+      throw new FileStorageException("파일 삭제 중 오류가 발생했습니다.", e);
+    }
+  }
+
+  @Override
+  public String getFileUrl(String fileName) {
+    return "/uploads/" + fileName;
+  }
+
+  private String getFileExtension(String filename) {
+    return filename.substring(filename.lastIndexOf("."));
+  }
+}

--- a/src/test/java/svsite/matzip/foody/domain/auth/ControllerTestSupport.java
+++ b/src/test/java/svsite/matzip/foody/domain/auth/ControllerTestSupport.java
@@ -1,19 +1,23 @@
 package svsite.matzip.foody.domain.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ser.std.FileSerializer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import svsite.matzip.foody.domain.auth.api.AuthController;
 import svsite.matzip.foody.domain.auth.service.AuthService;
+import svsite.matzip.foody.domain.image.api.ImageController;
 import svsite.matzip.foody.domain.post.api.PostController;
 import svsite.matzip.foody.domain.post.service.PostService;
 import svsite.matzip.foody.global.auth.AuthenticatedUserResolver;
+import svsite.matzip.foody.global.util.file.service.FileUploadService;
 
 @WebMvcTest(controllers = {
     AuthController.class,
-    PostController.class
+    PostController.class,
+    ImageController.class
 })
 public abstract class ControllerTestSupport {
   @Autowired
@@ -26,4 +30,6 @@ public abstract class ControllerTestSupport {
   protected AuthenticatedUserResolver authenticatedUserResolver;
   @MockBean
   protected PostService postService;
+  @MockBean
+  protected FileUploadService fileUploadService;
 }

--- a/src/test/java/svsite/matzip/foody/domain/image/api/ImageControllerTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/image/api/ImageControllerTest.java
@@ -1,0 +1,79 @@
+package svsite.matzip.foody.domain.image.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import svsite.matzip.foody.domain.auth.ControllerTestSupport;
+import svsite.matzip.foody.global.util.file.exception.FileUploadException;
+
+class ImageControllerTest extends ControllerTestSupport {
+
+  @Test
+  @DisplayName("이미지 파일 업로드에 성공한다")
+  void uploadImagesSuccess() throws Exception {
+    // given
+    MockMultipartFile mockFile1 = new MockMultipartFile("files", "image1.jpg", "image/jpeg", "test-image-1".getBytes());
+    MockMultipartFile mockFile2 = new MockMultipartFile("files", "image2.png", "image/png", "test-image-2".getBytes());
+
+    // 서비스가 반환할 업로드된 파일 URL 목록 Mock 설정
+    List<String> mockFileUrls = List.of("/uploads/image1.jpg", "/uploads/image2.png");
+    when(fileUploadService.uploadFiles(any())).thenReturn(mockFileUrls);
+
+    // when
+    mockMvc.perform(multipart("/images")
+            .file(mockFile1)
+            .file(mockFile2)
+            .contentType(MediaType.MULTIPART_FORM_DATA))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(mockFileUrls.size()))
+        .andExpect(jsonPath("$[0]").value("/uploads/image1.jpg"))
+        .andExpect(jsonPath("$[1]").value("/uploads/image2.png"));
+
+    // then
+    verify(fileUploadService).uploadFiles(any());
+  }
+
+  @Test
+  @DisplayName("파일이 없을 경우 400 에러를 반환한다")
+  void uploadImagesBadRequest() throws Exception {
+    // when
+    mockMvc.perform(multipart("/images")
+            .contentType(MediaType.MULTIPART_FORM_DATA))
+        .andExpect(status().isBadRequest());
+
+    // then
+    verify(fileUploadService, never()).uploadFiles(any());
+  }
+
+  @Test
+  @DisplayName("이미지 파일이 아닌 경우 400 에러를 반환한다")
+  void uploadInvalidFileType() throws Exception {
+    // given
+    MockMultipartFile invalidFile = new MockMultipartFile("files", "document.txt", "text/plain", "invalid-file".getBytes());
+
+    // Mock 예외 설정
+    when(fileUploadService.uploadFiles(any())).thenThrow(new FileUploadException("허용되지 않은 파일 형식입니다."));
+
+    // when
+    mockMvc.perform(multipart("/images")
+            .file(invalidFile)
+            .contentType(MediaType.MULTIPART_FORM_DATA))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.message").value("허용되지 않은 파일 형식입니다."));
+
+    // then
+    verify(fileUploadService).uploadFiles(any());
+  }
+}

--- a/src/test/java/svsite/matzip/foody/domain/post/service/PostServiceTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/post/service/PostServiceTest.java
@@ -103,7 +103,10 @@ class PostServiceTest {
 
     when(postRepository.save(any(Post.class))).thenAnswer(invocation -> {
       Post post = invocation.getArgument(0);
-      ReflectionTestUtils.setField(post, "id", 1L);  // save 후 ID 설정
+      ReflectionTestUtils.setField(post, "id", 1L);
+      if (post.getImages() == null) {
+        post.addImages(Collections.emptyList());
+      }
       return post;
     });
 
@@ -143,7 +146,8 @@ class PostServiceTest {
         "수정된 맛집 소개",
         "수정된 설명",
         LocalDateTime.of(2025, 2, 8, 15, 30, 0),
-        9
+        9,
+        Arrays.asList()
     );
 
     when(postRepository.findByPostIdAndUser(1L, mockUser)).thenReturn(Optional.of(existingPost));

--- a/src/test/java/svsite/matzip/foody/global/util/file/service/FileUploadServiceTest.java
+++ b/src/test/java/svsite/matzip/foody/global/util/file/service/FileUploadServiceTest.java
@@ -1,0 +1,123 @@
+package svsite.matzip.foody.global.util.file.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import svsite.matzip.foody.global.config.ImageConfig;
+import svsite.matzip.foody.global.util.file.exception.FileStorageException;
+import svsite.matzip.foody.global.util.file.exception.FileUploadException;
+
+@ExtendWith(MockitoExtension.class)
+class FileUploadServiceTest {
+
+  @InjectMocks
+  private FileUploadService fileUploadService;
+
+  @Mock
+  private FileStorageService fileStorageService;
+
+  @Mock
+  private ImageConfig imageConfig;
+
+  @Test
+  @DisplayName("이미지를 성공적으로 업로드한다")
+  void uploadFiles_Success() {
+    // given
+    MultipartFile mockFile1 = new MockMultipartFile("file1", "image1.jpg", "image/jpeg", "test-image-1".getBytes());
+    MultipartFile mockFile2 = new MockMultipartFile("file2", "image2.png", "image/png", "test-image-2".getBytes());
+
+    when(imageConfig.getMaxImageCount()).thenReturn(5);
+    when(imageConfig.getMaxImageSize()).thenReturn(10_000_000L);  // 10MB 제한
+    when(fileStorageService.saveFile(any(MultipartFile.class))).thenReturn("saved-file.jpg");
+    when(fileStorageService.getFileUrl(anyString())).thenReturn("http://localhost/uploads/saved-file.jpg");
+
+    // when
+    List<String> uploadedUrls = fileUploadService.uploadFiles(List.of(mockFile1, mockFile2));
+
+    // then
+    assertNotNull(uploadedUrls);
+    assertEquals(2, uploadedUrls.size());
+    assertTrue(uploadedUrls.contains("http://localhost/uploads/saved-file.jpg"));
+
+    verify(fileStorageService, times(2)).saveFile(any(MultipartFile.class));
+  }
+
+  @Test
+  @DisplayName("업로드 파일 개수가 제한을 초과할 경우 예외를 발생시킨다")
+  void uploadFiles_FileCountExceedsLimit() {
+    // given
+    List<MultipartFile> mockFiles = List.of(
+        new MockMultipartFile("file1", "image1.jpg", "image/jpeg", "test-image-1".getBytes()),
+        new MockMultipartFile("file2", "image2.jpg", "image/jpeg", "test-image-2".getBytes()),
+        new MockMultipartFile("file3", "image3.jpg", "image/jpeg", "test-image-3".getBytes())
+    );
+
+    when(imageConfig.getMaxImageCount()).thenReturn(2);  // 최대 2개 파일 제한
+
+    // when & then
+    FileUploadException exception = assertThrows(FileUploadException.class, () -> fileUploadService.uploadFiles(mockFiles));
+    assertEquals("최대 2개의 파일만 업로드할 수 있습니다.", exception.getMessage());
+
+    verify(fileStorageService, never()).saveFile(any(MultipartFile.class));
+  }
+
+  @Test
+  @DisplayName("파일 형식이 올바르지 않을 경우 예외를 발생시킨다")
+  void uploadFiles_InvalidFileType() {
+    // given
+    MultipartFile invalidFile = new MockMultipartFile("file", "document.txt", "text/plain", "invalid-file".getBytes());
+
+    when(imageConfig.getMaxImageCount()).thenReturn(5);
+
+    // when & then
+    FileUploadException exception = assertThrows(FileUploadException.class, () -> fileUploadService.uploadFiles(List.of(invalidFile)));
+    assertEquals("허용되지 않은 파일 형식입니다.", exception.getMessage());
+
+    verify(fileStorageService, never()).saveFile(any(MultipartFile.class));
+  }
+
+  @Test
+  @DisplayName("파일 크기가 제한을 초과할 경우 예외를 발생시킨다")
+  void uploadFiles_FileSizeExceedsLimit() {
+    // given
+    MultipartFile largeFile = new MockMultipartFile("file", "large-image.jpg", "image/jpeg", new byte[15_000_000]);  // 15MB 크기 파일
+
+    when(imageConfig.getMaxImageCount()).thenReturn(5);
+    when(imageConfig.getMaxImageSize()).thenReturn(10_000_000L);  // 10MB 제한
+
+    // when & then
+    FileUploadException exception = assertThrows(FileUploadException.class, () -> fileUploadService.uploadFiles(List.of(largeFile)));
+    assertEquals("파일 크기가 초과되었습니다. 최대 10000000 bytes까지 허용됩니다.", exception.getMessage());
+
+    verify(fileStorageService, never()).saveFile(any(MultipartFile.class));
+  }
+
+  @Test
+  @DisplayName("파일 저장 중 오류가 발생할 경우 예외를 발생시킨다")
+  void uploadFiles_FileStorageError() {
+    // given
+    MultipartFile mockFile = new MockMultipartFile("file", "image.jpg", "image/jpeg", "test-image".getBytes());
+
+    when(imageConfig.getMaxImageCount()).thenReturn(5);
+    when(imageConfig.getMaxImageSize()).thenReturn(10_000_000L);
+    when(fileStorageService.saveFile(mockFile)).thenThrow(new FileStorageException("파일 저장 중 오류 발생"));
+
+    // when & then
+    FileStorageException exception = assertThrows(FileStorageException.class, () -> fileUploadService.uploadFiles(List.of(mockFile)));
+    assertEquals("파일 저장 중 오류 발생", exception.getMessage());
+  }
+}

--- a/src/test/java/svsite/matzip/foody/global/util/file/service/LocalFileStorageServiceTest.java
+++ b/src/test/java/svsite/matzip/foody/global/util/file/service/LocalFileStorageServiceTest.java
@@ -1,0 +1,128 @@
+package svsite.matzip.foody.global.util.file.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+import svsite.matzip.foody.global.util.file.exception.FileStorageException;
+
+@ExtendWith(MockitoExtension.class)
+class LocalFileStorageServiceTest {
+
+  private LocalFileStorageService fileStorageService;
+
+  @TempDir
+  Path tempDir;
+
+  @BeforeEach
+  void setUp() {
+    fileStorageService = new LocalFileStorageService();
+    ReflectionTestUtils.setField(fileStorageService, "uploadDir", tempDir.toString());
+  }
+
+  @Test
+  @DisplayName("파일을 성공적으로 저장한다")
+  void saveFile_Success() throws Exception {
+    // given
+    MultipartFile mockFile = new MockMultipartFile("file", "image.jpg", "image/jpeg", "test-content".getBytes());
+
+    // when
+    String savedFileName = fileStorageService.saveFile(mockFile);
+
+    // then
+    assertNotNull(savedFileName, "저장된 파일 이름이 null이 아니어야 합니다.");
+    Path savedFilePath = tempDir.resolve(savedFileName);
+    assertTrue(Files.exists(savedFilePath), "저장된 파일이 존재해야 합니다.");
+    assertEquals("test-content", Files.readString(savedFilePath), "파일 내용이 일치해야 합니다.");
+  }
+
+  @Test
+  @DisplayName("파일 저장 중 오류가 발생하면 예외를 던진다")
+  void saveFile_Failure() throws Exception {
+    // given
+    MultipartFile mockFile = mock(MultipartFile.class);
+
+    when(mockFile.getOriginalFilename()).thenReturn("image.jpg");
+    doThrow(IOException.class).when(mockFile).transferTo(any(File.class));
+
+    // when & then
+    FileStorageException exception = assertThrows(FileStorageException.class, () -> fileStorageService.saveFile(mockFile));
+    assertEquals("파일 저장 중 오류 발생", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("파일을 성공적으로 삭제한다")
+  void deleteFile_Success() throws Exception {
+    // given
+    String fileName = "test-file.txt";
+    Path filePath = Files.createFile(tempDir.resolve(fileName));
+
+    // when
+    fileStorageService.deleteFile(fileName);
+
+    // then
+    assertFalse(Files.exists(filePath), "파일이 삭제되어야 합니다.");
+  }
+
+  @Test
+  @DisplayName("삭제하려는 파일이 존재하지 않으면 경고 로그를 출력한다")
+  void deleteFile_FileNotFound() {
+    // given
+    String nonExistentFile = "non-existent-file.txt";
+
+    // when & then
+    fileStorageService.deleteFile(nonExistentFile);
+
+    // 로그 확인은 어렵기 때문에 예외가 발생하지 않는지 검증
+    assertDoesNotThrow(() -> fileStorageService.deleteFile(nonExistentFile));
+  }
+
+  @Test
+  @DisplayName("파일 삭제 중 오류가 발생하면 예외를 던진다")
+  void deleteFile_Failure() throws Exception {
+    // given
+    String fileName = "test-file.txt";
+    Path filePath = tempDir.resolve(fileName);
+    Files.createFile(filePath);
+
+    // 파일 삭제 중 IOException 발생 시뮬레이션
+    try (MockedStatic<Files> mockedFiles = mockStatic(Files.class)) {
+      mockedFiles.when(() -> Files.delete(any(Path.class))).thenThrow(IOException.class);
+
+      // when & then
+      FileStorageException exception = assertThrows(FileStorageException.class, () -> fileStorageService.deleteFile(fileName));
+      assertEquals("파일 삭제 중 오류가 발생했습니다.", exception.getMessage());
+    }
+  }
+
+  @Test
+  @DisplayName("파일 URL을 반환한다")
+  void getFileUrl() {
+    // given
+    String fileName = "image.jpg";
+
+    // when
+    String fileUrl = fileStorageService.getFileUrl(fileName);
+
+    // then
+    assertEquals("/uploads/" + fileName, fileUrl);
+  }
+}


### PR DESCRIPTION
### **1. PR 개요**
파일 업로드 기능을 구현하였습니다. `ImageController`, `FileUploadService`, `LocalFileStorageService`를 통해 이미지 업로드 및 관리 기능을 제공합니다.

---

### **2. 주요 변경 사항 및 설명**

1) **이미지 업로드 기능 구현**  
이미지 업로드를 위한 API를 추가했습니다.  
- 사용자는 여러 개의 이미지를 한 번에 업로드할 수 있습니다.  
- 업로드한 파일의 개수와 크기에 대한 제한 조건이 있으며, 이를 서비스에서 검증합니다.  

**API 경로:** `/images` (POST)

```java
@PostMapping("/images")
public ResponseEntity<List<String>> uploadImages(
    @AuthenticatedUser User user,
    @RequestParam("files") List<MultipartFile> files
)
```

---

2) **파일 저장 로직 구현**  
- 파일 업로드 디렉토리는 설정 파일에서 정의된 경로(`file.upload-dir`)를 사용합니다.  
- 로컬 개발 환경에서는 `LocalFileStorageService`를 통해 파일을 저장 및 삭제합니다.  
- 저장된 파일의 URL은 `/uploads/{파일명}` 형태로 반환합니다.

---

3) **서비스 및 유효성 검증 로직**  
`FileUploadService`에서 파일의 개수, 형식, 크기를 검증한 후 파일을 저장합니다.  
- **파일 개수 제한**: `image.max-count`  
- **파일 크기 제한**: `image.max-size`

```java
public List<String> uploadFiles(List<MultipartFile> files) {
    validateFileCount(files.size());
    return files.stream()
                .map(this::validateAndSaveFile)
                .collect(Collectors.toList());
}

private void validateFileCount(int size) {
    if (size > imageConfig.getMaxImageCount()) {
        throw new FileUploadException("최대 " + imageConfig.getMaxImageCount() + "개의 파일만 업로드할 수 있습니다.", HttpStatus.BAD_REQUEST);
    }
}

private String validateAndSaveFile(MultipartFile file) {
    if (!Objects.requireNonNull(file.getContentType()).startsWith("image/")) {
        throw new FileUploadException("허용되지 않은 파일 형식입니다.", HttpStatus.UNSUPPORTED_MEDIA_TYPE);
    }
    if (file.getSize() > imageConfig.getMaxImageSize()) {
        throw new FileUploadException("파일 크기가 초과되었습니다.", HttpStatus.PAYLOAD_TOO_LARGE);
    }
    return fileStorageService.saveFile(file);
}
```

---

4) **Swagger(OpenAPI) 문서화**  
- API에 대해 Swagger 명세를 추가하여 문서화했습니다.  
- 파일 업로드 시 `multipart/form-data` 형식이 적용되도록 설정했습니다.  

---

### **3. 설계 의도 및 고려 사항**

1) **트러블 슈팅 기록**  
- 테스트 코드 작성 중 `MockMultipartFile`이 Mockito에서 조작되지 않는 문제 발생.  
    - 원인: Spring의 `MockMultipartFile`은 Mock 객체가 아니므로 `Mockito.when()`에서 직접 제어할 수 없음.
    - 해결: `MultipartFile` 인터페이스를 Mock으로 생성하여 테스트 수행.
  
- 로컬 환경에서 파일 저장 시 디렉토리 권한 문제로 파일 접근이 제한되는 오류 발생.
    - 해결: JUnit의 `@TempDir`을 활용하여 임시 폴더를 사용하고 파일 입출력 테스트 수행.

2) **예외 처리 설계**  
- 파일 개수, 형식, 크기와 관련된 예외를 `FileUploadException`으로 처리하고 응답 상태 코드를 명확히 전달합니다.

3) **테스트 및 확장성 고려**  
- 로컬 환경 외에도 AWS S3 등 외부 저장소에 대응할 수 있도록 인터페이스 기반의 `FileStorageService`를 설계했습니다.

---

### **4. 테스트 및 검증**

1) **단위 테스트**  
- 파일 업로드 및 저장 테스트 (`FileUploadServiceTest`, `LocalFileStorageServiceTest`)
- 각 예외 상황(파일 개수 초과, 형식 오류, 크기 초과 등)에 대한 테스트 수행.

2) **통합 테스트**  
- API 요청을 통해 실제 업로드 및 응답 데이터를 검증했습니다.  
- Swagger UI에서 API 명세 확인 및 테스트 완료.

---

### **5. 기타 참고 사항**

1) **API 명세 확인**  
Swagger UI 경로: `/swagger-ui.html`  
- API 명세에 따라 업로드 시 필요한 파라미터와 응답 형식을 확인할 수 있습니다.  

2) **추가 개발 계획**  
- 운영 환경에서는 AWS S3 또는 별도의 파일 저장소로 전환할 수 있도록 기능 확장을 고려하고 있습니다.

---

This closes #17