### PR TITLE
맛집 피드 즐겨찾기 기능 구현

### DIFF
--- a/src/main/java/svsite/matzip/foody/domain/favorite/api/FavoriteController.java
+++ b/src/main/java/svsite/matzip/foody/domain/favorite/api/FavoriteController.java
@@ -1,0 +1,75 @@
+package svsite.matzip.foody.domain.favorite.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.favorite.api.response.ToggleFavoriteResponseDto;
+import svsite.matzip.foody.domain.favorite.service.FavoriteService;
+import svsite.matzip.foody.domain.post.api.dto.response.PostResponseDto;
+import svsite.matzip.foody.global.auth.AuthenticatedUser;
+
+@Tag(name = "Favorite", description = "게시글 즐겨찾기 API")
+@RequestMapping("/favorites")
+@RestController
+@RequiredArgsConstructor
+public class FavoriteController {
+
+  private final FavoriteService favoriteService;
+
+  @Operation(
+      summary = "게시글 즐겨찾기 토글",
+      description = "특정 게시글의 즐겨찾기 상태를 추가 또는 제거합니다.",
+      security = @SecurityRequirement(name = "bearerAuth")
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "즐겨찾기 토글 성공 (변경된 게시글 ID 반환)"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글"),
+      @ApiResponse(responseCode = "401", description = "인증 실패"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
+  @PostMapping("/{id}")
+  public ResponseEntity<ToggleFavoriteResponseDto> toggleFavorite(
+      @Parameter(description = "즐겨찾기할 게시글 ID", example = "1", required = true)
+      @PathVariable long id,
+      @AuthenticatedUser User user
+  ) {
+    return ResponseEntity.ok().body(favoriteService.toggleFavorite(id, user));
+  }
+
+  @Operation(
+      summary = "내 즐겨찾기 게시글 목록 조회",
+      description = "사용자가 즐겨찾기한 게시글 목록을 페이지 단위로 조회합니다.",
+      security = @SecurityRequirement(name = "bearerAuth")
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "즐겨찾기 목록 조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 실패"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
+  @GetMapping("/my")
+  public ResponseEntity<Page<PostResponseDto>> getMyFavoritePosts(
+      @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+      @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+      @Parameter(description = "페이지 당 게시글 개수", example = "10")
+      @RequestParam(defaultValue = "10") @PositiveOrZero int size,
+      @AuthenticatedUser User user
+  ) {
+    return ResponseEntity.ok()
+        .body(favoriteService.getMyFavoritePosts(PageRequest.of(page, size), user));
+  }
+}

--- a/src/main/java/svsite/matzip/foody/domain/favorite/api/response/ToggleFavoriteResponseDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/favorite/api/response/ToggleFavoriteResponseDto.java
@@ -1,0 +1,15 @@
+package svsite.matzip.foody.domain.favorite.api.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "즐겨찾기 토글 응답 DTO")
+public record ToggleFavoriteResponseDto(
+
+    @Schema(description = "게시글 ID", example = "1", requiredMode = REQUIRED)
+    Long postId,
+
+    @Schema(description = "즐겨찾기 등록 여부", example = "true", requiredMode = REQUIRED)
+    boolean isFavorite
+) {}

--- a/src/main/java/svsite/matzip/foody/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/svsite/matzip/foody/domain/favorite/repository/FavoriteRepository.java
@@ -1,0 +1,22 @@
+package svsite.matzip.foody.domain.favorite.repository;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.favorite.entity.Favorite;
+import svsite.matzip.foody.domain.post.entity.Post;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    Optional<Favorite> findByPostAndUser(Post post, User user);
+
+    @Query("SELECT f FROM Favorite f " +
+            "JOIN FETCH f.post p " +
+            "LEFT JOIN FETCH p.images i " +
+            "WHERE f.user = :user " +
+            "ORDER BY p.date DESC")
+    Page<Favorite> findFavoritesByUser(@Param("user") User user, Pageable pageable);
+}

--- a/src/main/java/svsite/matzip/foody/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/svsite/matzip/foody/domain/favorite/service/FavoriteService.java
@@ -1,0 +1,50 @@
+package svsite.matzip.foody.domain.favorite.service;
+
+import static svsite.matzip.foody.global.exception.errorCode.ErrorCodes.POST_NOT_FOUND;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.favorite.api.response.ToggleFavoriteResponseDto;
+import svsite.matzip.foody.domain.favorite.entity.Favorite;
+import svsite.matzip.foody.domain.favorite.repository.FavoriteRepository;
+import svsite.matzip.foody.domain.post.api.dto.response.PostResponseDto;
+import svsite.matzip.foody.domain.post.entity.Post;
+import svsite.matzip.foody.domain.post.repository.PostRepository;
+import svsite.matzip.foody.global.exception.support.CustomException;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+    private final FavoriteRepository favoriteRepository;
+    private final PostRepository postRepository;
+
+    public ToggleFavoriteResponseDto toggleFavorite(long postId, User user) {
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
+        Optional<Favorite> existingFavorite = favoriteRepository.findByPostAndUser(post, user);
+
+        existingFavorite.ifPresentOrElse(
+            favoriteRepository::delete,
+            () -> {
+                Favorite newFavorite = Favorite.builder().post(post).user(user).build();
+                favoriteRepository.save(newFavorite);
+            }
+        );
+
+        boolean isFavorite = existingFavorite.isEmpty();
+        return new ToggleFavoriteResponseDto(postId, isFavorite);
+    }
+
+
+    @Transactional(readOnly = true)
+    public Page<PostResponseDto> getMyFavoritePosts(Pageable pageable, User user) {
+        return favoriteRepository.findFavoritesByUser(user, pageable)
+            .map(favorite -> PostResponseDto.fromWithFavorite(favorite.getPost(), true));
+    }
+}

--- a/src/main/java/svsite/matzip/foody/domain/image/entity/Image.java
+++ b/src/main/java/svsite/matzip/foody/domain/image/entity/Image.java
@@ -24,6 +24,7 @@ import svsite.matzip.foody.global.entity.BaseEntity;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Image extends BaseEntity {
+
   @Id
   @GeneratedValue
   private Long id;
@@ -31,15 +32,22 @@ public class Image extends BaseEntity {
   private String uri;
 
   @ManyToOne(fetch = LAZY)
-  @JoinColumn(name="post_id")
+  @JoinColumn(name = "post_id")
   Post post;
 
   public void associateWithPost(Post post) {
+    if (this.post == post) {
+      return;
+    }
+
     if (this.post != null) {
       this.post.getImages().remove(this);
     }
+
     this.post = post;
-    if (post != null && !post.getImages().contains(this)) {
+
+    if (post != null && post.getImages().stream()
+        .noneMatch(image -> image.getUri().equals(this.uri))) {
       post.getImages().add(this);
     }
   }
@@ -54,11 +62,12 @@ public class Image extends BaseEntity {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if(!(o instanceof Image image)) return false;
-    return id != null && id.equals(image.id);
+    if (!(o instanceof Image image)) return false;
+    return (id != null ? id.equals(image.id) : uri.equals(image.uri));
   }
+
   @Override
   public int hashCode() {
-    return Objects.hash(getId());
+    return id != null ? Objects.hash(id) : Objects.hash(uri);
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/api/dto/response/PostResponseDto.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/api/dto/response/PostResponseDto.java
@@ -1,5 +1,6 @@
 package svsite.matzip.foody.domain.post.api.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -35,10 +36,21 @@ public record PostResponseDto(
     @Schema(description = "수정 날짜 및 시간", example = "2025-02-08T13:00:00")
     LocalDateTime updatedAt,
     @Schema(description = "게시글에 첨부된 이미지 목록")
-    List<ImageResponseDto> images
+    List<ImageResponseDto> images,
+    @Schema(description = "즐겨찾기 유무")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Boolean isFavorite
 ) {
 
   public static PostResponseDto from(Post post) {
+    return from(post, null);
+  }
+
+  public static PostResponseDto fromWithFavorite(Post post, boolean isFavorite) {
+    return from(post, isFavorite);
+  }
+
+  public static PostResponseDto from(Post post, Boolean isFavorite) {
     return PostResponseDto.builder()
         .id(post.getId())
         .latitude(post.getLatitude())
@@ -50,8 +62,8 @@ public record PostResponseDto(
         .date(post.getDate())
         .score(post.getScore())
         .images(post.getImages().stream()
-            .sorted(Comparator.comparingLong(
-                image -> Optional.ofNullable(image.getId()).orElse(0L)))
+            .sorted(
+                Comparator.comparingLong(image -> Optional.ofNullable(image.getId()).orElse(0L)))
             .map(image -> ImageResponseDto.builder()
                 .id(image.getId())
                 .uri(image.getUri())
@@ -62,6 +74,7 @@ public record PostResponseDto(
             .toList())
         .createdAt(post.getCreatedAt())
         .updatedAt(post.getUpdatedAt())
+        .isFavorite(isFavorite)
         .build();
   }
 }

--- a/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
+++ b/src/main/java/svsite/matzip/foody/domain/post/service/PostService.java
@@ -51,6 +51,8 @@ public class PostService {
         .map(uri -> Image.builder().uri(uri).build())
         .toList());
 
+    post = postRepository.save(post);
+
     return PostResponseDto.from(post);
   }
 

--- a/src/test/java/svsite/matzip/foody/domain/auth/ControllerTestSupport.java
+++ b/src/test/java/svsite/matzip/foody/domain/auth/ControllerTestSupport.java
@@ -1,13 +1,14 @@
 package svsite.matzip.foody.domain.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.std.FileSerializer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import svsite.matzip.foody.domain.auth.api.AuthController;
 import svsite.matzip.foody.domain.auth.service.AuthService;
+import svsite.matzip.foody.domain.favorite.api.FavoriteController;
+import svsite.matzip.foody.domain.favorite.service.FavoriteService;
 import svsite.matzip.foody.domain.image.api.ImageController;
 import svsite.matzip.foody.domain.post.api.PostController;
 import svsite.matzip.foody.domain.post.service.PostService;
@@ -17,7 +18,8 @@ import svsite.matzip.foody.global.util.file.service.FileUploadService;
 @WebMvcTest(controllers = {
     AuthController.class,
     PostController.class,
-    ImageController.class
+    ImageController.class,
+    FavoriteController.class
 })
 public abstract class ControllerTestSupport {
   @Autowired
@@ -32,4 +34,7 @@ public abstract class ControllerTestSupport {
   protected PostService postService;
   @MockBean
   protected FileUploadService fileUploadService;
+  @MockBean
+  protected FavoriteService favoriteService;
+
 }

--- a/src/test/java/svsite/matzip/foody/domain/favorite/api/FavoriteControllerTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/favorite/api/FavoriteControllerTest.java
@@ -1,0 +1,85 @@
+package svsite.matzip.foody.domain.favorite.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import svsite.matzip.foody.domain.auth.ControllerTestSupport;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.favorite.api.response.ToggleFavoriteResponseDto;
+import svsite.matzip.foody.domain.post.api.dto.response.PostResponseDto;
+import svsite.matzip.foody.domain.post.entity.MarkerColor;
+
+class FavoriteControllerTest extends ControllerTestSupport {
+
+  private final String AUTH_HEADER = "Bearer validToken";
+
+  @Test
+  @DisplayName("게시글 즐겨찾기를 성공적으로 토글한다")
+  void toggleFavorite_success() throws Exception {
+    // given
+    long postId = 1L;
+    ToggleFavoriteResponseDto responseDto = new ToggleFavoriteResponseDto(postId, true);
+
+    when(favoriteService.toggleFavorite(eq(postId), any(User.class))).thenReturn(responseDto);
+
+    // when & then
+    mockMvc.perform(post("/favorites/{id}", postId)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.postId").value(postId))
+        .andExpect(jsonPath("$.isFavorite").value(true))
+        .andDo(print());
+
+    verify(favoriteService).toggleFavorite(eq(postId), any(User.class));
+  }
+
+  @Test
+  @DisplayName("내 즐겨찾기 게시글 목록을 성공적으로 조회한다")
+  void getMyFavoritePosts_success() throws Exception {
+    // given
+    List<PostResponseDto> favoritePosts = List.of(
+        new PostResponseDto(1L, BigDecimal.valueOf(37.5665), BigDecimal.valueOf(126.9780),
+            MarkerColor.RED, "서울특별시 종로구", "맛집 소개 1", "맛집 설명", LocalDateTime.now(),
+            9, LocalDateTime.now(), LocalDateTime.now(), List.of(), true),
+        new PostResponseDto(2L, BigDecimal.valueOf(35.1796), BigDecimal.valueOf(129.0756),
+            MarkerColor.BLUE, "부산광역시 중구", "맛집 소개 2", "맛집 설명", LocalDateTime.now(),
+            8, LocalDateTime.now(), LocalDateTime.now(), List.of(), true)
+    );
+    Page<PostResponseDto> responsePage = new PageImpl<>(favoritePosts);
+
+    when(favoriteService.getMyFavoritePosts(any(PageRequest.class), any(User.class))).thenReturn(responsePage);
+
+    // when & then
+    mockMvc.perform(get("/favorites/my")
+            .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+            .param("page", "0")
+            .param("size", "10")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content.length()").value(2))
+        .andExpect(jsonPath("$.content[0].id").value(1L))
+        .andExpect(jsonPath("$.content[0].title").value("맛집 소개 1"))
+        .andExpect(jsonPath("$.content[1].title").value("맛집 소개 2"))
+        .andDo(print());
+
+    verify(favoriteService).getMyFavoritePosts(any(PageRequest.class), any(User.class));
+  }
+}

--- a/src/test/java/svsite/matzip/foody/domain/favorite/service/FavoriteServiceTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/favorite/service/FavoriteServiceTest.java
@@ -1,0 +1,149 @@
+package svsite.matzip.foody.domain.favorite.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static svsite.matzip.foody.global.exception.errorCode.ErrorCodes.POST_NOT_FOUND;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import svsite.matzip.foody.domain.auth.entity.User;
+import svsite.matzip.foody.domain.favorite.api.response.ToggleFavoriteResponseDto;
+import svsite.matzip.foody.domain.favorite.entity.Favorite;
+import svsite.matzip.foody.domain.favorite.repository.FavoriteRepository;
+import svsite.matzip.foody.domain.post.api.dto.response.PostResponseDto;
+import svsite.matzip.foody.domain.post.entity.MarkerColor;
+import svsite.matzip.foody.domain.post.entity.Post;
+import svsite.matzip.foody.domain.post.repository.PostRepository;
+import svsite.matzip.foody.global.exception.support.CustomException;
+
+@ExtendWith(MockitoExtension.class)
+class FavoriteServiceTest {
+
+  @InjectMocks
+  private FavoriteService favoriteService;
+
+  @Mock
+  private FavoriteRepository favoriteRepository;
+
+  @Mock
+  private PostRepository postRepository;
+
+  @Test
+  @DisplayName("게시글 즐겨찾기 토글 - 즐겨찾기 추가")
+  void toggleFavorite_add() {
+    // given
+    long postId = 1L;
+    User mockUser = User.builder().email("test@example.com").build();
+    Post mockPost = createMockPost(postId);
+
+    when(postRepository.findById(postId)).thenReturn(Optional.of(mockPost));
+    when(favoriteRepository.findByPostAndUser(mockPost, mockUser)).thenReturn(Optional.empty());
+
+    // when
+    ToggleFavoriteResponseDto response = favoriteService.toggleFavorite(postId, mockUser);
+
+    // then
+    assertNotNull(response, "응답은 null이 아니어야 합니다.");
+    assertTrue(response.isFavorite(), "즐겨찾기가 추가되어야 합니다.");
+    assertEquals(postId, response.postId(), "반환된 게시글 ID가 일치해야 합니다.");
+
+    verify(favoriteRepository).save(any(Favorite.class));
+  }
+
+  @Test
+  @DisplayName("게시글 즐겨찾기 토글 - 즐겨찾기 삭제")
+  void toggleFavorite_remove() {
+    // given
+    long postId = 1L;
+    User mockUser = User.builder().email("test@example.com").build();
+    Post mockPost = createMockPost(postId);
+    Favorite existingFavorite = Favorite.builder().post(mockPost).user(mockUser).build();
+
+    when(postRepository.findById(postId)).thenReturn(Optional.of(mockPost));
+    when(favoriteRepository.findByPostAndUser(mockPost, mockUser)).thenReturn(Optional.of(existingFavorite));
+
+    // when
+    ToggleFavoriteResponseDto response = favoriteService.toggleFavorite(postId, mockUser);
+
+    // then
+    assertNotNull(response, "응답은 null이 아니어야 합니다.");
+    assertFalse(response.isFavorite(), "즐겨찾기가 제거되어야 합니다.");
+    assertEquals(postId, response.postId(), "반환된 게시글 ID가 일치해야 합니다.");
+
+    verify(favoriteRepository).delete(existingFavorite);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 게시글에 대해 즐겨찾기 토글 시 예외 발생")
+  void toggleFavorite_postNotFound_throwsException() {
+    // given
+    long postId = 1L;
+    User mockUser = User.builder().email("test@example.com").build();
+
+    when(postRepository.findById(postId)).thenReturn(Optional.empty());
+
+    // when & then
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      favoriteService.toggleFavorite(postId, mockUser);
+    });
+
+    assertEquals(POST_NOT_FOUND.defaultMessage(), exception.getMessage(), "예외 메시지가 예상과 일치해야 합니다.");
+    verify(favoriteRepository, never()).save(any(Favorite.class));
+  }
+
+  @Test
+  @DisplayName("사용자가 즐겨찾기한 게시글 목록을 페이지 단위로 조회한다")
+  void getMyFavoritePosts() {
+    // given
+    User mockUser = User.builder().email("test@example.com").build();
+    PageRequest pageable = PageRequest.of(0, 10);
+
+    List<Favorite> favorites = List.of(
+        Favorite.builder().post(createMockPost(1L)).user(mockUser).build(),
+        Favorite.builder().post(createMockPost(2L)).user(mockUser).build()
+    );
+
+    Page<Favorite> favoritePage = new PageImpl<>(favorites, pageable, favorites.size());
+
+    when(favoriteRepository.findFavoritesByUser(mockUser, pageable)).thenReturn(favoritePage);
+
+    // when
+    Page<PostResponseDto> responsePage = favoriteService.getMyFavoritePosts(pageable, mockUser);
+
+    // then
+    assertNotNull(responsePage, "결과 페이지는 null이 아니어야 합니다.");
+    assertEquals(2, responsePage.getContent().size(), "게시글 개수가 예상과 일치해야 합니다.");
+    assertEquals(1L, responsePage.getContent().get(0).id(), "첫 번째 게시글 ID가 예상 값과 일치해야 합니다.");
+
+    verify(favoriteRepository).findFavoritesByUser(mockUser, pageable);
+  }
+
+  private Post createMockPost(Long id) {
+    return Post.builder()
+        .id(id)
+        .latitude(BigDecimal.valueOf(37.5665))
+        .longitude(BigDecimal.valueOf(126.9780))
+        .color(MarkerColor.RED)
+        .address("서울특별시 종로구")
+        .title("맛집 소개")
+        .description("맛집 설명")
+        .date(LocalDateTime.now())
+        .score(9)
+        .user(User.builder().email("test@example.com").build())
+        .build();
+  }
+}

--- a/src/test/java/svsite/matzip/foody/domain/post/service/PostServiceTest.java
+++ b/src/test/java/svsite/matzip/foody/domain/post/service/PostServiceTest.java
@@ -151,6 +151,7 @@ class PostServiceTest {
     );
 
     when(postRepository.findByPostIdAndUser(1L, mockUser)).thenReturn(Optional.of(existingPost));
+    when(postRepository.save(any(Post.class))).thenAnswer(invocation -> invocation.getArgument(0));  // Mock 설정 추가
 
     // when
     PostResponseDto responseDto = postService.updatePost(1L, updatePostDto, mockUser);
@@ -164,6 +165,7 @@ class PostServiceTest {
     assertEquals(updatePostDto.date(), responseDto.date(), "날짜가 예상 값과 일치해야 합니다.");
 
     verify(postRepository).findByPostIdAndUser(1L, mockUser);
+    verify(postRepository).save(any(Post.class));
   }
 
   @Test


### PR DESCRIPTION
### **1. PR 개요**  
게시글 즐겨찾기 기능을 구현하였습니다.

---

### **2. 주요 변경 사항 및 설명**

##### **1) 즐겨찾기 토글 기능 구현**
- 특정 게시글에 대해 즐겨찾기를 추가하거나 제거하는 기능을 추가하였습니다.
- 즐겨찾기 상태가 변경된 게시글의 ID와 상태 값을 반환합니다.

##### **2) 즐겨찾기한 게시글 목록 조회 기능 구현**
- 사용자가 즐겨찾기한 게시글 목록을 페이지 단위로 조회할 수 있습니다.
- 조회 시 관련 이미지와 함께 반환하며, 각 게시글에 대해 `isFavorite = true`로 응답합니다.

##### **3) Favorite 관련 엔티티, 레포지토리, 서비스 및 컨트롤러 작성**
1. **엔티티 및 레포지토리**  
   - `Favorite` 엔티티에 대해 `FavoriteRepository` 작성  
   - 사용자별 즐겨찾기된 게시글을 페이징하여 조회하는 메서드 추가  
   - `findFavoritesByUser`: JPQL 쿼리를 사용해 게시글 정보와 이미지 정보를 페치 조인

2. **서비스**  
   - `FavoriteService`에서 토글 기능 및 페이징 조회 기능 구현
   - `toggleFavorite`: 즐겨찾기가 존재할 경우 삭제, 없을 경우 생성  
   - `getMyFavoritePosts`: 사용자별 즐겨찾기 게시글을 페이징하여 반환  

3. **컨트롤러 및 Swagger 문서화**  
   - `FavoriteController`에서 API 제공  

##### **4) 테스트**
  - **즐겨찾기 토글** 테스트: 성공 케이스 및 예외 케이스 (게시글이 없는 경우 등)  
  - **즐겨찾기 목록 조회** 테스트: 페이지별 정상 조회 및 빈 결과 반환 케이스  

---

### **3. 설계 의도 및 고려 사항**
- 게시글이 삭제된 경우 즐겨찾기 데이터는 자동으로 제거되도록 설정 (`orphanRemoval = true`).
- JWT 인증을 사용하여 현재 사용자 정보를 기반으로 즐겨찾기 데이터를 처리.
- 즐겨찾기 추가와 제거가 같은 API에서 처리되도록 `toggleFavorite` 방식 채택.

---

### **4. 테스트 및 검증**
- **즐겨찾기 토글** API에 대한 성공 및 예외 테스트 완료  
- **즐겨찾기 목록 조회** 기능에 대한 페이징 테스트 수행

---

### **5. 기타 참고 사항**

---

This closes #19 